### PR TITLE
Use the configured API URL instead of the stored URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@toznysecure/account-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toznysecure/account-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Javascript SDK for performing Tozny platform account level operations",
   "main": "src/index.js",
   "publishConfig": {

--- a/src/account.js
+++ b/src/account.js
@@ -121,9 +121,9 @@ class Account {
       KEY_HASH_ROUNDS
     )
     const clientCreds = await this.crypto.decryptString(encClient, encKey)
-    const storageClient = new this.Storage.Client(
-      this.Storage.Config.fromObject(clientCreds)
-    )
+    const storageConfig = this.Storage.Config.fromObject(clientCreds)
+    storageConfig.apiUrl = this.api.apiUrl
+    const storageClient = new this.Storage.Client(storageConfig)
     return new Client(
       clientApi,
       profile.account,


### PR DESCRIPTION
Updates the account client instantiation to ensure the API URL used is always the configured value instead of the stored value.