### PR TITLE
Client migration on Login 

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -188,7 +188,29 @@ class API {
     })
     return validateRequestAsJSON(request)
   }
-
+  /**
+   * backfillSigningKeys updates the existing v1 client credentials to include a 
+   * signing key
+   * 
+   * @param {object} queenClient the client to be migrated from v1 to v2 
+   * @param {string} publicSigningKey the public signing key generated
+   * @param {string} clientID the Tozny Client ID for the client 
+   *
+   * @return {Promise<object>} The Client Object
+   */
+  async backfillSigningKeys(queenClient, publicSigningKey, clientID) {
+    const body = JSON.stringify({
+      signing_keys: publicSigningKey,
+    })
+    const request =  await queenClient.authenticator.tokenFetch(this.apiUrl + '/v1/client/' + clientID +'/keys', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body,
+    })
+    return validateRequestAsJSON(request)
+  }
   /** requests email verification for a tozny account
    *
    *  Displays error to user if
@@ -455,7 +477,7 @@ class API {
    * @return {Promise<object>} The raw webhook object written
    */
   async createWebhook(queenClient, webhook_url, triggers) {
-    const webhookTriggers = triggers.map(eventString => {
+    const webhookTriggers = triggers.map((eventString) => {
       return {
         enabled: true,
         api_event: eventString,
@@ -653,8 +675,8 @@ class API {
     const url = [`${this.apiUrl}/v1/identity/realm/${realmName}/identity`]
     const query = { first, max }
     const queryString = Object.keys(query)
-      .filter(k => !!query[k])
-      .map(k => `${k}=${encodeURIComponent(query[k])}`)
+      .filter((k) => !!query[k])
+      .map((k) => `${k}=${encodeURIComponent(query[k])}`)
       .join('&')
     if (queryString) {
       url.push(queryString)

--- a/src/client.js
+++ b/src/client.js
@@ -382,7 +382,7 @@ class Client {
     }
     // Do this async to speed it up just slightly.
     response.identities = await Promise.all(
-      response.identities.map(async i => BasicIdentity.decode(i))
+      response.identities.map(async (i) => BasicIdentity.decode(i))
     )
     return response
   }

--- a/src/types/clientInfoList.js
+++ b/src/types/clientInfoList.js
@@ -39,7 +39,7 @@ class ClientInfoList {
    */
   static decode(json) {
     let clients = json.clients
-      ? [...json.clients].map(c => ClientInfo.decode(c))
+      ? [...json.clients].map((c) => ClientInfo.decode(c))
       : []
     return new ClientInfoList(clients, json.next_token)
   }


### PR DESCRIPTION
When users log in and are detected to be a version 1 client (no signing key), we will call the backfill endpoint in order to update their keys! 
This is the logic for setting the client as version 1
https://github.com/tozny/js-sdk/blob/6679b5eb9384f79777b57a265026b7543cbc81cc/lib/storage/config.js#L56