### PR TITLE
[WR-108] adds create, read, delete realm groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ const realmName = 'westeros'
 await accountClient.deleteRealm(realmName)
 ```
 
+**Create a group**
+```js
+const realmName = 'westeros'
+const myNewGroup = {
+  name: "WhiteWalkers",
+}
+const group = await accountClient.createRealmGroup(realmName, myNewGroup)
+```
+
 **Create a realm role**
 ```js
 const realmName = 'westeros'
@@ -216,7 +225,6 @@ const realmName = 'westeros'
 const roleId = '000000000000-0000-0000-0000-00000000'
 await accountClient.deleteRealmRole(realmName, roleId)
 ```
-
 
 **List identities in a realm**
 
@@ -246,7 +254,7 @@ for (let realmRole in details.roles.realm) {
   console.log(realmRole.name)
 }
 // where 'kingGuard' is the name of a client application in the realm
-for (let clientRole in details.roles.clients.kindsGuard) {
+for (let clientRole in details.roles.clients.kingGuard) {
   console.log(clientRole.name)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ const myNewGroup = {
 const group = await accountClient.createRealmGroup(realmName, myNewGroup)
 ```
 
+**List groups in a realm**
+```js
+const realmName = 'westeros'
+const groups = await accountClient.listRealmGroups(realmName)
+```
+
+**Delete a realm group**
+```js
+const realmName = 'westeros'
+const groupId = '000000000000-0000-0000-0000-00000000'
+await accountClient.deleteRealmGroup(realmName, groupId)
+```
+
 **Create a realm role**
 ```js
 const realmName = 'westeros'

--- a/dist/api/index.js
+++ b/dist/api/index.js
@@ -570,6 +570,22 @@ class API {
             return utils_1.validateRequestAsJSON(response);
         });
     }
+    /**
+     * Requests the creation of a new TozID Realm.
+     *
+     * @param {object} queenClient The queen client for the account to delete the realm from.
+     * @param {string} realmName The name of the realm to delete.
+     *
+     * @return {Promise<object>} Empty object.
+     */
+    deleteRealm(queenClient, realmName) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const response = yield queenClient.authenticator.tsv1Fetch(this.apiUrl + `/v1/identity/realm/${realmName}`, {
+                method: 'DELETE',
+            });
+            return utils_1.validateRequestAsJSON(response);
+        });
+    }
     getAggregations(queenClient, accountId, startTime, endTime) {
         return __awaiter(this, void 0, void 0, function* () {
             const body = JSON.stringify({
@@ -587,27 +603,20 @@ class API {
         });
     }
     /**
-     * Requests the creation of a new TozID Realm.
-     *
-     * @param {object} queenClient The queen client for the account to delete the realm from.
-     * @param {string} realmName The name of the realm to delete.
-     *
-     * @return {Promise<object>} Empty object.
-     */
-    deleteRealm(queenClient, realmName) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const response = yield queenClient.authenticator.tsv1Fetch(this.apiUrl + `/v1/identity/realm/${realmName}`, {
-                method: 'DELETE',
-            });
-            return utils_1.validateRequestAsJSON(response);
-        });
-    }
-    /**
      * Creates a new group for the requested realm.
      */
     createRealmGroup(queenClient, realmName, group) {
         return __awaiter(this, void 0, void 0, function* () {
             return realmGroups_1.createRealmGroup({ realmName, group }, { apiUrl: this.apiUrl, queenClient });
+        });
+    }
+    /**
+     * Deletes a realm group by id.
+     */
+    deleteRealmGroup(queenClient, realmName, groupId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield realmGroups_1.deleteRealmGroup({ realmName, groupId }, { apiUrl: this.apiUrl, queenClient });
+            return true;
         });
     }
     /**

--- a/dist/api/index.js
+++ b/dist/api/index.js
@@ -611,6 +611,14 @@ class API {
         });
     }
     /**
+     * Lists all groups for the request realm.
+     */
+    listRealmGroups(queenClient, realmName) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return realmGroups_1.listRealmGroups({ realmName }, { apiUrl: this.apiUrl, queenClient });
+        });
+    }
+    /**
      * Creates a new role for the requested realm.
      */
     createRealmRole(queenClient, realmName, role) {

--- a/dist/api/index.js
+++ b/dist/api/index.js
@@ -21,6 +21,7 @@ const realmRoles_1 = require("./realmRoles");
 const token_1 = __importDefault(require("./token"));
 const utils_1 = require("../utils");
 const constants_1 = require("../utils/constants");
+const realmGroups_1 = require("./realmGroups");
 /**
  * API abstracts over the actual API calls made for various account-level operations.
  */
@@ -599,6 +600,14 @@ class API {
                 method: 'DELETE',
             });
             return utils_1.validateRequestAsJSON(response);
+        });
+    }
+    /**
+     * Creates a new group for the requested realm.
+     */
+    createRealmGroup(queenClient, realmName, group) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return realmGroups_1.createRealmGroup({ realmName, group }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**

--- a/dist/api/realmGroups.js
+++ b/dist/api/realmGroups.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.createRealmGroup = void 0;
+exports.listRealmGroups = exports.createRealmGroup = void 0;
 const utils_1 = require("../utils");
 function createRealmGroup({ realmName, group }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -21,3 +21,11 @@ function createRealmGroup({ realmName, group }, { apiUrl, queenClient }) {
     });
 }
 exports.createRealmGroup = createRealmGroup;
+function listRealmGroups({ realmName }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group`, { method: 'GET' });
+        const { groups } = (yield utils_1.validateRequestAsJSON(response));
+        return groups;
+    });
+}
+exports.listRealmGroups = listRealmGroups;

--- a/dist/api/realmGroups.js
+++ b/dist/api/realmGroups.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.listRealmGroups = exports.createRealmGroup = void 0;
+exports.listRealmGroups = exports.deleteRealmGroup = exports.createRealmGroup = void 0;
 const utils_1 = require("../utils");
 function createRealmGroup({ realmName, group }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -21,6 +21,14 @@ function createRealmGroup({ realmName, group }, { apiUrl, queenClient }) {
     });
 }
 exports.createRealmGroup = createRealmGroup;
+function deleteRealmGroup({ realmName, groupId }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}`, { method: 'DELETE' });
+        utils_1.checkStatus(response);
+        return;
+    });
+}
+exports.deleteRealmGroup = deleteRealmGroup;
 function listRealmGroups({ realmName }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group`, { method: 'GET' });

--- a/dist/api/realmGroups.js
+++ b/dist/api/realmGroups.js
@@ -1,0 +1,23 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createRealmGroup = void 0;
+const utils_1 = require("../utils");
+function createRealmGroup({ realmName, group }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group`, {
+            method: 'POST',
+            body: JSON.stringify(group),
+        });
+        return utils_1.validateRequestAsJSON(response);
+    });
+}
+exports.createRealmGroup = createRealmGroup;

--- a/dist/client.js
+++ b/dist/client.js
@@ -11,7 +11,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 const { validateStorageClient } = require('./utils');
 const API = require('./api').default;
 const { KEY_HASH_ROUNDS } = require('./utils/constants');
-const { AccountBillingStatus, RegistrationToken, Realm, Realms, Identity, ClientInfo, ClientInfoList, Role, } = require('./types');
+const { AccountBillingStatus, RegistrationToken, Realm, Realms, Identity, ClientInfo, ClientInfoList, Role, Group, } = require('./types');
 const Refresher = require('./api/refresher');
 const Token = require('./api/token');
 const BasicIdentity = require('./types/basicIdentity');
@@ -269,6 +269,31 @@ class Client {
         });
     }
     /**
+     * Requests the deletion of a named TozID Realm belonging to the account.
+     *
+     * @param {string} realmName The name for the realm to delete.
+     *
+     * @returns {Promise<Object>} Empty object.
+     */
+    deleteRealm(realmName) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.api.deleteRealm(this.queenClient, realmName);
+        });
+    }
+    /**
+     * Creates a new group in the realm.
+     *
+     * @param {string} realmName Name of realm.
+     * @param {object} group     Object containing `name` of group.
+     * @returns {Promise<Group>} The newly created group.
+     */
+    createRealmGroup(realmName, group) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const rawResponse = yield this.api.createRealmGroup(this.queenClient, realmName, group);
+            return Group.decode(rawResponse);
+        });
+    }
+    /**
      * Creates a new role for a realm.
      *
      * @param {string} realmName  Name of realm.
@@ -303,18 +328,6 @@ class Client {
         return __awaiter(this, void 0, void 0, function* () {
             const rawResponse = yield this.api.listRealmRoles(this.queenClient, realmName);
             return rawResponse.map(Role.decode);
-        });
-    }
-    /**
-     * Requests the deletion of a named TozID Realm belonging to the account.
-     *
-     * @param {string} realmName The name for the realm to delete.
-     *
-     * @returns {Promise<Object>} Empty object.
-     */
-    deleteRealm(realmName) {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this.api.deleteRealm(this.queenClient, realmName);
         });
     }
     /**

--- a/dist/client.js
+++ b/dist/client.js
@@ -306,6 +306,18 @@ class Client {
         });
     }
     /**
+     * Deletes a group in the named realm by id.
+     *
+     * @param {string} realmName   The name of the realm containing the group.
+     * @param {string} groupId     The id of the group to delete.
+     * @returns {Promise<boolean>} True if successful.
+     */
+    deleteRealmGroup(realmName, groupId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.api.deleteRealmGroup(this.queenClient, realmName, groupId);
+        });
+    }
+    /**
      * Creates a new role for a realm.
      *
      * @param {string} realmName  Name of realm.

--- a/dist/client.js
+++ b/dist/client.js
@@ -294,6 +294,18 @@ class Client {
         });
     }
     /**
+     * Lists all realm groups for a realm.
+     *
+     * @param {string} realmName  Name of realm.
+     * @returns {Promise<Group[]>} List of all groups at realm.
+     */
+    listRealmGroups(realmName) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const rawResponse = yield this.api.listRealmGroups(this.queenClient, realmName);
+            return rawResponse.map(Group.decode);
+        });
+    }
+    /**
      * Creates a new role for a realm.
      *
      * @param {string} realmName  Name of realm.

--- a/jest.config.js
+++ b/jest.config.js
@@ -157,6 +157,9 @@ module.exports = {
   // This option allows use of a custom test runner
   // testRunner: "jasmine2",
 
+  // Default timeout of a test in milliseconds.
+  testTimeout: 10000,
+
   // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
   // testURL: "http://localhost",
 

--- a/src/__tests__/realm.test.js
+++ b/src/__tests__/realm.test.js
@@ -5,9 +5,6 @@ const BasicIdentity = require('../types/basicIdentity')
 const DetailedIdentity = require('../types/detailedIdentity')
 const { cleanupRealms } = require('./utils')
 
-// Set really high for slower APIs.
-jest.setTimeout(100000)
-
 const accountFactory = new Account(Tozny, process.env.API_URL)
 let client = null
 let registrationToken = null

--- a/src/__tests__/realmGroups.test.ts
+++ b/src/__tests__/realmGroups.test.ts
@@ -34,5 +34,11 @@ describe('Realm Groups', () => {
 
     expect(adminGroup.id).toBeTruthy()
     expect(adminGroup.name).toBe('Admins')
+
+    const groups = await client.listRealmGroups(realmName)
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].id).toBe(adminGroup.id)
+    expect(groups[0].name).toBe('Admins')
   })
 })

--- a/src/__tests__/realmGroups.test.ts
+++ b/src/__tests__/realmGroups.test.ts
@@ -27,7 +27,8 @@ afterAll(async () => {
 })
 
 describe('Realm Groups', () => {
-  it('creates realm groups', async () => {
+  it('creates, lists, & deletes realm groups', async () => {
+    // creation of group
     const adminGroup = await client.createRealmGroup(realmName, {
       name: 'Admins',
     })
@@ -35,10 +36,21 @@ describe('Realm Groups', () => {
     expect(adminGroup.id).toBeTruthy()
     expect(adminGroup.name).toBe('Admins')
 
+    // list groups
     const groups = await client.listRealmGroups(realmName)
 
     expect(groups).toHaveLength(1)
     expect(groups[0].id).toBe(adminGroup.id)
     expect(groups[0].name).toBe('Admins')
+
+    // deletes groups
+    const deleteSuccessful = await client.deleteRealmGroup(
+      realmName,
+      adminGroup.id
+    )
+    expect(deleteSuccessful).toBeTruthy()
+
+    // ensure it really was deleted
+    expect(await client.listRealmGroups(realmName)).toHaveLength(0)
   })
 })

--- a/src/__tests__/realmGroups.test.ts
+++ b/src/__tests__/realmGroups.test.ts
@@ -1,0 +1,38 @@
+import Account from '../account'
+// @ts-ignore no type defs exist for js-sdk
+import Tozny from '@toznysecure/sdk/node'
+import { v4 as uuidv4 } from 'uuid'
+import { cleanupRealms } from './utils'
+
+const accountFactory = new Account(Tozny, process.env.API_URL)
+let client: any = null
+let realmName: string
+
+beforeAll(async () => {
+  // Create an account to re-use across test cases
+  const seed = uuidv4()
+  const name = `Test Account ${seed}`
+  const email = `test+${seed}@tozny.com`
+  const password = uuidv4()
+  const registration: any = await accountFactory.register(name, email, password)
+  client = registration.client
+
+  realmName = `TestRealm${seed.split('-')[0]}`
+  const sovereignName = 'YassQueen'
+  await client.createRealm(realmName, sovereignName)
+})
+
+afterAll(async () => {
+  await cleanupRealms(client)
+})
+
+describe('Realm Groups', () => {
+  it('creates realm groups', async () => {
+    const adminGroup = await client.createRealmGroup(realmName, {
+      name: 'Admins',
+    })
+
+    expect(adminGroup.id).toBeTruthy()
+    expect(adminGroup.name).toBe('Admins')
+  })
+})

--- a/src/__tests__/realmRoles.test.ts
+++ b/src/__tests__/realmRoles.test.ts
@@ -5,9 +5,6 @@ import { v4 as uuidv4 } from 'uuid'
 import { cleanupRealms } from './utils'
 import { Role } from '../types'
 
-// default of 5s is sometimes, but not always, enough time. give the tests 10s
-jest.setTimeout(10000)
-
 const accountFactory = new Account(Tozny, process.env.API_URL)
 let client: any = null
 let realmName: string

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,7 +9,7 @@ import Role, { ToznyAPIRole } from '../types/role'
 import { validateRequestAsJSON, checkStatus } from '../utils'
 import { DEFAULT_API_URL } from '../utils/constants'
 import { ToznyAPIGroup } from '../types/group'
-import { createRealmGroup } from './realmGroups'
+import { createRealmGroup, listRealmGroups } from './realmGroups'
 
 // this is a placeholder until we have real types from js-sdk
 type ToznyClient = any
@@ -650,6 +650,16 @@ class API {
       { realmName, group },
       { apiUrl: this.apiUrl, queenClient }
     )
+  }
+
+  /**
+   * Lists all groups for the request realm.
+   */
+  async listRealmGroups(
+    queenClient: ToznyClient,
+    realmName: string
+  ): Promise<ToznyAPIGroup[]> {
+    return listRealmGroups({ realmName }, { apiUrl: this.apiUrl, queenClient })
   }
 
   /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,7 +9,11 @@ import Role, { ToznyAPIRole } from '../types/role'
 import { validateRequestAsJSON, checkStatus } from '../utils'
 import { DEFAULT_API_URL } from '../utils/constants'
 import { ToznyAPIGroup } from '../types/group'
-import { createRealmGroup, listRealmGroups } from './realmGroups'
+import {
+  createRealmGroup,
+  deleteRealmGroup,
+  listRealmGroups,
+} from './realmGroups'
 
 // this is a placeholder until we have real types from js-sdk
 type ToznyClient = any
@@ -603,23 +607,6 @@ class API {
     return validateRequestAsJSON(response)
   }
 
-  async getAggregations(queenClient, accountId, startTime, endTime) {
-    const body = JSON.stringify({
-      account_id: accountId,
-      range: {
-        start_time: startTime,
-        end_time: endTime,
-      },
-    })
-    const response = await queenClient.authenticator.tokenFetch(
-      this.apiUrl + `/v1/metric/requests/aggregations`,
-      {
-        method: 'POST',
-        body: body,
-      }
-    )
-    return validateRequestAsJSON(response)
-  }
   /**
    * Requests the creation of a new TozID Realm.
    *
@@ -638,6 +625,24 @@ class API {
     return validateRequestAsJSON(response)
   }
 
+  async getAggregations(queenClient, accountId, startTime, endTime) {
+    const body = JSON.stringify({
+      account_id: accountId,
+      range: {
+        start_time: startTime,
+        end_time: endTime,
+      },
+    })
+    const response = await queenClient.authenticator.tokenFetch(
+      this.apiUrl + `/v1/metric/requests/aggregations`,
+      {
+        method: 'POST',
+        body: body,
+      }
+    )
+    return validateRequestAsJSON(response)
+  }
+
   /**
    * Creates a new group for the requested realm.
    */
@@ -650,6 +655,21 @@ class API {
       { realmName, group },
       { apiUrl: this.apiUrl, queenClient }
     )
+  }
+
+  /**
+   * Deletes a realm group by id.
+   */
+  async deleteRealmGroup(
+    queenClient: ToznyClient,
+    realmName: string,
+    groupId: string
+  ): Promise<boolean> {
+    await deleteRealmGroup(
+      { realmName, groupId },
+      { apiUrl: this.apiUrl, queenClient }
+    )
+    return true
   }
 
   /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,8 @@ import Token from './token'
 import Role, { ToznyAPIRole } from '../types/role'
 import { validateRequestAsJSON, checkStatus } from '../utils'
 import { DEFAULT_API_URL } from '../utils/constants'
+import { ToznyAPIGroup } from '../types/group'
+import { createRealmGroup } from './realmGroups'
 
 // this is a placeholder until we have real types from js-sdk
 type ToznyClient = any
@@ -634,6 +636,20 @@ class API {
       }
     )
     return validateRequestAsJSON(response)
+  }
+
+  /**
+   * Creates a new group for the requested realm.
+   */
+  async createRealmGroup(
+    queenClient: ToznyClient,
+    realmName: string,
+    group: { name: string }
+  ): Promise<ToznyAPIGroup> {
+    return createRealmGroup(
+      { realmName, group },
+      { apiUrl: this.apiUrl, queenClient }
+    )
   }
 
   /**

--- a/src/api/realmGroups.ts
+++ b/src/api/realmGroups.ts
@@ -1,5 +1,5 @@
 import { ToznyAPIGroup } from '../types/group'
-import { validateRequestAsJSON } from '../utils'
+import { checkStatus, validateRequestAsJSON } from '../utils'
 import { APIContext } from './context'
 
 type CreateRealmGroupData = {
@@ -19,6 +19,19 @@ export async function createRealmGroup(
     }
   )
   return validateRequestAsJSON(response)
+}
+
+type DeleteRealmGroupData = { realmName: string; groupId: string }
+export async function deleteRealmGroup(
+  { realmName, groupId }: DeleteRealmGroupData,
+  { apiUrl, queenClient }: APIContext
+): Promise<void> {
+  const response = await queenClient.authenticator.tsv1Fetch(
+    `${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}`,
+    { method: 'DELETE' }
+  )
+  checkStatus(response)
+  return
 }
 
 type ListRealmGroupData = { realmName: string }

--- a/src/api/realmGroups.ts
+++ b/src/api/realmGroups.ts
@@ -1,0 +1,22 @@
+import { ToznyAPIGroup } from '../types/group'
+import { validateRequestAsJSON } from '../utils'
+import { APIContext } from './context'
+
+type CreateRealmGroupData = {
+  realmName: string
+  group: { name: string }
+}
+
+export async function createRealmGroup(
+  { realmName, group }: CreateRealmGroupData,
+  { apiUrl, queenClient }: APIContext
+): Promise<ToznyAPIGroup> {
+  const response = await queenClient.authenticator.tsv1Fetch(
+    `${apiUrl}/v1/identity/realm/${realmName}/group`,
+    {
+      method: 'POST',
+      body: JSON.stringify(group),
+    }
+  )
+  return validateRequestAsJSON(response)
+}

--- a/src/api/realmGroups.ts
+++ b/src/api/realmGroups.ts
@@ -20,3 +20,19 @@ export async function createRealmGroup(
   )
   return validateRequestAsJSON(response)
 }
+
+type ListRealmGroupData = { realmName: string }
+type ListRealmGroupsResponse = { groups: ToznyAPIGroup[] }
+export async function listRealmGroups(
+  { realmName }: ListRealmGroupData,
+  { apiUrl, queenClient }: APIContext
+): Promise<ToznyAPIGroup[]> {
+  const response = await queenClient.authenticator.tsv1Fetch(
+    `${apiUrl}/v1/identity/realm/${realmName}/group`,
+    { method: 'GET' }
+  )
+  const { groups } = (await validateRequestAsJSON(
+    response
+  )) as ListRealmGroupsResponse
+  return groups
+}

--- a/src/client.js
+++ b/src/client.js
@@ -10,6 +10,7 @@ const {
   ClientInfo,
   ClientInfoList,
   Role,
+  Group,
 } = require('./types')
 const Refresher = require('./api/refresher')
 const Token = require('./api/token')
@@ -303,6 +304,33 @@ class Client {
   }
 
   /**
+   * Requests the deletion of a named TozID Realm belonging to the account.
+   *
+   * @param {string} realmName The name for the realm to delete.
+   *
+   * @returns {Promise<Object>} Empty object.
+   */
+  async deleteRealm(realmName) {
+    return this.api.deleteRealm(this.queenClient, realmName)
+  }
+
+  /**
+   * Creates a new group in the realm.
+   *
+   * @param {string} realmName Name of realm.
+   * @param {object} group     Object containing `name` of group.
+   * @returns {Promise<Group>} The newly created group.
+   */
+  async createRealmGroup(realmName, group) {
+    const rawResponse = await this.api.createRealmGroup(
+      this.queenClient,
+      realmName,
+      group
+    )
+    return Group.decode(rawResponse)
+  }
+
+  /**
    * Creates a new role for a realm.
    *
    * @param {string} realmName  Name of realm.
@@ -341,17 +369,6 @@ class Client {
       realmName
     )
     return rawResponse.map(Role.decode)
-  }
-
-  /**
-   * Requests the deletion of a named TozID Realm belonging to the account.
-   *
-   * @param {string} realmName The name for the realm to delete.
-   *
-   * @returns {Promise<Object>} Empty object.
-   */
-  async deleteRealm(realmName) {
-    return this.api.deleteRealm(this.queenClient, realmName)
   }
 
   /**

--- a/src/client.js
+++ b/src/client.js
@@ -331,6 +331,20 @@ class Client {
   }
 
   /**
+   * Lists all realm groups for a realm.
+   *
+   * @param {string} realmName  Name of realm.
+   * @returns {Promise<Group[]>} List of all groups at realm.
+   */
+  async listRealmGroups(realmName) {
+    const rawResponse = await this.api.listRealmGroups(
+      this.queenClient,
+      realmName
+    )
+    return rawResponse.map(Group.decode)
+  }
+
+  /**
    * Creates a new role for a realm.
    *
    * @param {string} realmName  Name of realm.

--- a/src/client.js
+++ b/src/client.js
@@ -345,6 +345,17 @@ class Client {
   }
 
   /**
+   * Deletes a group in the named realm by id.
+   *
+   * @param {string} realmName   The name of the realm containing the group.
+   * @param {string} groupId     The id of the group to delete.
+   * @returns {Promise<boolean>} True if successful.
+   */
+  async deleteRealmGroup(realmName, groupId) {
+    return this.api.deleteRealmGroup(this.queenClient, realmName, groupId)
+  }
+
+  /**
    * Creates a new role for a realm.
    *
    * @param {string} realmName  Name of realm.


### PR DESCRIPTION
* Adds realm group management powers to the account client.
* Additionally increases the test default timeout to 10s to remove some test file boilerplate for slow API calls.

Please disregard reviewing code in `dist` 😀 

NOTE: tests passing on this branch depend on as-of-yet uncommitted changes to how the server code responds with empty lists.