### PR TITLE
[WR-108] add describe methods for roles & groups

### DIFF
--- a/dist/api/index.js
+++ b/dist/api/index.js
@@ -620,6 +620,14 @@ class API {
         });
     }
     /**
+     * Describe a single realm group by id.
+     */
+    describeRealmGroup(queenClient, realmName, groupId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return realmGroups_1.describeRealmGroup({ realmName, groupId }, { apiUrl: this.apiUrl, queenClient });
+        });
+    }
+    /**
      * Lists all groups for the request realm.
      */
     listRealmGroups(queenClient, realmName) {
@@ -642,6 +650,14 @@ class API {
         return __awaiter(this, void 0, void 0, function* () {
             yield realmRoles_1.deleteRealmRole({ realmName, roleId }, { apiUrl: this.apiUrl, queenClient });
             return true;
+        });
+    }
+    /**
+     * Describe a single realm role by id.
+     */
+    describeRealmRole(queenClient, realmName, roleId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return realmRoles_1.describeRealmRole({ realmName, roleId }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**

--- a/dist/api/realmGroups.js
+++ b/dist/api/realmGroups.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.listRealmGroups = exports.deleteRealmGroup = exports.createRealmGroup = void 0;
+exports.listRealmGroups = exports.describeRealmGroup = exports.deleteRealmGroup = exports.createRealmGroup = void 0;
 const utils_1 = require("../utils");
 function createRealmGroup({ realmName, group }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -29,6 +29,13 @@ function deleteRealmGroup({ realmName, groupId }, { apiUrl, queenClient }) {
     });
 }
 exports.deleteRealmGroup = deleteRealmGroup;
+function describeRealmGroup({ realmName, groupId }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}`, { method: 'GET' });
+        return utils_1.validateRequestAsJSON(response);
+    });
+}
+exports.describeRealmGroup = describeRealmGroup;
 function listRealmGroups({ realmName }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group`, { method: 'GET' });

--- a/dist/api/realmRoles.js
+++ b/dist/api/realmRoles.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.listRealmRoles = exports.deleteRealmRole = exports.createRealmRole = void 0;
+exports.listRealmRoles = exports.describeRealmRole = exports.deleteRealmRole = exports.createRealmRole = void 0;
 const utils_1 = require("../utils");
 function createRealmRole({ realmName, role }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -29,6 +29,13 @@ function deleteRealmRole({ realmName, roleId }, { apiUrl, queenClient }) {
     });
 }
 exports.deleteRealmRole = deleteRealmRole;
+function describeRealmRole({ realmName, roleId }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/role/${roleId}`, { method: 'GET' });
+        return utils_1.validateRequestAsJSON(response);
+    });
+}
+exports.describeRealmRole = describeRealmRole;
 function listRealmRoles({ realmName }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/role`, { method: 'GET' });

--- a/dist/client.js
+++ b/dist/client.js
@@ -294,6 +294,18 @@ class Client {
         });
     }
     /**
+     * Describe a realm group by id.
+     *
+     * @param {string} realmName Name of realm.
+     * @param {string} groupId   Id of group to describe.
+     * @returns {Promise<Group>}
+     */
+    describeRealmGroup(realmName, groupId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.api.describeRealmGroup(this.queenClient, realmName, groupId);
+        });
+    }
+    /**
      * Lists all realm groups for a realm.
      *
      * @param {string} realmName  Name of realm.
@@ -340,6 +352,18 @@ class Client {
     deleteRealmRole(realmName, roleId) {
         return __awaiter(this, void 0, void 0, function* () {
             return this.api.deleteRealmRole(this.queenClient, realmName, roleId);
+        });
+    }
+    /**
+     * Describe a realm role by id.
+     *
+     * @param {string} realmName Name of realm.
+     * @param {string} roleId    Id of role to describe.
+     * @returns {Promise<Role>}
+     */
+    describeRealmRole(realmName, roleId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.api.describeRealmRole(this.queenClient, realmName, roleId);
         });
     }
     /**

--- a/src/__tests__/realmGroups.test.ts
+++ b/src/__tests__/realmGroups.test.ts
@@ -53,4 +53,22 @@ describe('Realm Groups', () => {
     // ensure it really was deleted
     expect(await client.listRealmGroups(realmName)).toHaveLength(0)
   })
+
+  it('describes a group by id', async () => {
+    const veggies = await client.createRealmGroup(realmName, {
+      name: 'Vegetables',
+    })
+
+    const described = await client.describeRealmGroup(realmName, veggies.id)
+    expect(described.id).toBe(veggies.id)
+    expect(described.name).toBe('Vegetables')
+
+    // sad but true, we throw 500 on nonexistent entity, not 404
+    await expect(
+      client.describeRealmGroup(
+        realmName,
+        '000000000000-0000-0000-0000-00000000'
+      )
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Internal Server Error"`)
+  })
 })

--- a/src/__tests__/realmRoles.test.ts
+++ b/src/__tests__/realmRoles.test.ts
@@ -72,4 +72,23 @@ describe('Realm Roles', () => {
     expect(listed).toHaveLength(3)
     expect(listed.map(r => r.id)).not.toContain(chef.id)
   })
+
+  it('describes a role by id', async () => {
+    const chef = await client.createRealmRole(realmName, {
+      name: 'Chef',
+      description: 'They cook things.',
+    })
+
+    const described = await client.describeRealmRole(realmName, chef.id)
+    expect(described.id).toBe(chef.id)
+    expect(described.name).toBe('Chef')
+
+    // sad but true, we throw 500 on nonexistent entity, not 404
+    await expect(
+      client.describeRealmRole(
+        realmName,
+        '000000000000-0000-0000-0000-00000000'
+      )
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Internal Server Error"`)
+  })
 })

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,7 +3,12 @@
  * Account level API request definitions.
  */
 import fetch from 'isomorphic-fetch'
-import { createRealmRole, deleteRealmRole, listRealmRoles } from './realmRoles'
+import {
+  createRealmRole,
+  deleteRealmRole,
+  describeRealmRole,
+  listRealmRoles,
+} from './realmRoles'
 import Token from './token'
 import Role, { ToznyAPIRole } from '../types/role'
 import { validateRequestAsJSON, checkStatus } from '../utils'
@@ -12,6 +17,7 @@ import { ToznyAPIGroup } from '../types/group'
 import {
   createRealmGroup,
   deleteRealmGroup,
+  describeRealmGroup,
   listRealmGroups,
 } from './realmGroups'
 
@@ -673,6 +679,20 @@ class API {
   }
 
   /**
+   * Describe a single realm group by id.
+   */
+  async describeRealmGroup(
+    queenClient: ToznyClient,
+    realmName: string,
+    groupId: string
+  ): Promise<ToznyAPIGroup> {
+    return describeRealmGroup(
+      { realmName, groupId },
+      { apiUrl: this.apiUrl, queenClient }
+    )
+  }
+
+  /**
    * Lists all groups for the request realm.
    */
   async listRealmGroups(
@@ -709,6 +729,20 @@ class API {
       { apiUrl: this.apiUrl, queenClient }
     )
     return true
+  }
+
+  /**
+   * Describe a single realm role by id.
+   */
+  async describeRealmRole(
+    queenClient: ToznyClient,
+    realmName: string,
+    roleId: string
+  ): Promise<ToznyAPIRole> {
+    return describeRealmRole(
+      { realmName, roleId },
+      { apiUrl: this.apiUrl, queenClient }
+    )
   }
 
   /**

--- a/src/api/realmGroups.ts
+++ b/src/api/realmGroups.ts
@@ -34,6 +34,18 @@ export async function deleteRealmGroup(
   return
 }
 
+type DescribeRealmGroupData = { realmName: string; groupId: string }
+export async function describeRealmGroup(
+  { realmName, groupId }: DescribeRealmGroupData,
+  { apiUrl, queenClient }: APIContext
+): Promise<void> {
+  const response = await queenClient.authenticator.tsv1Fetch(
+    `${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}`,
+    { method: 'GET' }
+  )
+  return validateRequestAsJSON(response)
+}
+
 type ListRealmGroupData = { realmName: string }
 type ListRealmGroupsResponse = { groups: ToznyAPIGroup[] }
 export async function listRealmGroups(

--- a/src/api/realmRoles.ts
+++ b/src/api/realmRoles.ts
@@ -34,6 +34,18 @@ export async function deleteRealmRole(
   return
 }
 
+type DescribeRealmRoleData = { realmName: string; roleId: string }
+export async function describeRealmRole(
+  { realmName, roleId }: DescribeRealmRoleData,
+  { apiUrl, queenClient }: APIContext
+): Promise<ToznyAPIRole> {
+  const response = await queenClient.authenticator.tsv1Fetch(
+    `${apiUrl}/v1/identity/realm/${realmName}/role/${roleId}`,
+    { method: 'GET' }
+  )
+  return validateRequestAsJSON(response)
+}
+
 type ListRealmRoleData = { realmName: string }
 type ListRealmRolesResponse = { roles: ToznyAPIRole[] }
 export async function listRealmRoles(

--- a/src/client.js
+++ b/src/client.js
@@ -331,6 +331,17 @@ class Client {
   }
 
   /**
+   * Describe a realm group by id.
+   *
+   * @param {string} realmName Name of realm.
+   * @param {string} groupId   Id of group to describe.
+   * @returns {Promise<Group>}
+   */
+  async describeRealmGroup(realmName, groupId) {
+    return this.api.describeRealmGroup(this.queenClient, realmName, groupId)
+  }
+
+  /**
    * Lists all realm groups for a realm.
    *
    * @param {string} realmName  Name of realm.
@@ -380,6 +391,17 @@ class Client {
    */
   async deleteRealmRole(realmName, roleId) {
     return this.api.deleteRealmRole(this.queenClient, realmName, roleId)
+  }
+
+  /**
+   * Describe a realm role by id.
+   *
+   * @param {string} realmName Name of realm.
+   * @param {string} roleId    Id of role to describe.
+   * @returns {Promise<Role>}
+   */
+  async describeRealmRole(realmName, roleId) {
+    return this.api.describeRealmRole(this.queenClient, realmName, roleId)
   }
 
   /**


### PR DESCRIPTION
realized that we also want the ability to describe single roles/groups by id. added those methods as `describeRealm*` a la the go client.

please disregard reviewing `dist/`.

also [WR-111]

[WR-111]: https://toznysecurity.atlassian.net/browse/WR-111