### PR TITLE
[WR-114] group-role mapping management

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ for (let realmRole in details.roles.realm) {
   console.log(realmRole.name)
 }
 // where 'kingGuard' is the name of a client application in the realm
-for (let clientRole in details.roles.clients.kingGuard) {
+for (let clientRole in details.roles.client.kingGuard) {
   console.log(clientRole.name)
 }
 ```

--- a/dist/api/groupRoleMappings.js
+++ b/dist/api/groupRoleMappings.js
@@ -9,12 +9,24 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.listGroupRoleMappings = void 0;
+exports.addGroupRoleMappings = exports.listGroupRoleMappings = void 0;
 const utils_1 = require("../utils");
+const roleMappingForGroupUri = (apiUrl, realmName, groupId) => `${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}/role_mapping`;
 function listGroupRoleMappings({ groupId, realmName }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
-        const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}/role_mapping`, { method: 'GET' });
+        const response = yield queenClient.authenticator.tsv1Fetch(roleMappingForGroupUri(apiUrl, realmName, groupId), { method: 'GET' });
         return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.listGroupRoleMappings = listGroupRoleMappings;
+function addGroupRoleMappings({ realmName, groupId, groupRoleMapping }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield queenClient.authenticator.tsv1Fetch(roleMappingForGroupUri(apiUrl, realmName, groupId), {
+            method: 'POST',
+            body: JSON.stringify(groupRoleMapping),
+        });
+        utils_1.checkStatus(response);
+        return;
+    });
+}
+exports.addGroupRoleMappings = addGroupRoleMappings;

--- a/dist/api/groupRoleMappings.js
+++ b/dist/api/groupRoleMappings.js
@@ -1,0 +1,20 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.listGroupRoleMappings = void 0;
+const utils_1 = require("../utils");
+function listGroupRoleMappings({ groupId, realmName }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}/role_mapping`, { method: 'GET' });
+        return utils_1.validateRequestAsJSON(response);
+    });
+}
+exports.listGroupRoleMappings = listGroupRoleMappings;

--- a/dist/api/groupRoleMappings.js
+++ b/dist/api/groupRoleMappings.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.addGroupRoleMappings = exports.listGroupRoleMappings = void 0;
+exports.removeGroupRoleMappings = exports.addGroupRoleMappings = exports.listGroupRoleMappings = void 0;
 const utils_1 = require("../utils");
 const roleMappingForGroupUri = (apiUrl, realmName, groupId) => `${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}/role_mapping`;
 function listGroupRoleMappings({ groupId, realmName }, { apiUrl, queenClient }) {
@@ -30,3 +30,14 @@ function addGroupRoleMappings({ realmName, groupId, groupRoleMapping }, { apiUrl
     });
 }
 exports.addGroupRoleMappings = addGroupRoleMappings;
+function removeGroupRoleMappings({ realmName, groupId, groupRoleMapping }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield queenClient.authenticator.tsv1Fetch(roleMappingForGroupUri(apiUrl, realmName, groupId), {
+            method: 'DELETE',
+            body: JSON.stringify(groupRoleMapping),
+        });
+        utils_1.checkStatus(response);
+        return;
+    });
+}
+exports.removeGroupRoleMappings = removeGroupRoleMappings;

--- a/dist/api/index.js
+++ b/dist/api/index.js
@@ -678,6 +678,15 @@ class API {
         });
     }
     /**
+     * Maps a particular realm group to a set of realm & client roles.
+     */
+    addGroupRoleMappings(queenClient, realmName, groupId, groupRoleMapping) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield groupRoleMappings_1.addGroupRoleMappings({ realmName, groupId, groupRoleMapping }, { apiUrl: this.apiUrl, queenClient });
+            return true;
+        });
+    }
+    /**
      * Gets the public info about the Tozny hosted broker
      *
      * @return {Promise<object>} The hosted broker public info.

--- a/dist/api/index.js
+++ b/dist/api/index.js
@@ -22,6 +22,7 @@ const token_1 = __importDefault(require("./token"));
 const utils_1 = require("../utils");
 const constants_1 = require("../utils/constants");
 const realmGroups_1 = require("./realmGroups");
+const groupRoleMappings_1 = require("./groupRoleMappings");
 /**
  * API abstracts over the actual API calls made for various account-level operations.
  */
@@ -666,6 +667,14 @@ class API {
     listRealmRoles(queenClient, realmName) {
         return __awaiter(this, void 0, void 0, function* () {
             return realmRoles_1.listRealmRoles({ realmName }, { apiUrl: this.apiUrl, queenClient });
+        });
+    }
+    /**
+     * Gets realm & client roles that are mapped to a particular realm group.
+     */
+    listGroupRoleMappings(queenClient, realmName, groupId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return groupRoleMappings_1.listGroupRoleMappings({ groupId, realmName }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**

--- a/dist/api/index.js
+++ b/dist/api/index.js
@@ -687,6 +687,15 @@ class API {
         });
     }
     /**
+     * Removes a set of realm/client roles from a group's role mapping.
+     */
+    removeGroupRoleMappings(queenClient, realmName, groupId, groupRoleMapping) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield groupRoleMappings_1.removeGroupRoleMappings({ realmName, groupId, groupRoleMapping }, { apiUrl: this.apiUrl, queenClient });
+            return true;
+        });
+    }
+    /**
      * Gets the public info about the Tozny hosted broker
      *
      * @return {Promise<object>} The hosted broker public info.

--- a/dist/client.js
+++ b/dist/client.js
@@ -11,7 +11,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 const { validateStorageClient } = require('./utils');
 const API = require('./api').default;
 const { KEY_HASH_ROUNDS } = require('./utils/constants');
-const { AccountBillingStatus, RegistrationToken, Realm, Realms, Identity, ClientInfo, ClientInfoList, Role, Group, } = require('./types');
+const { AccountBillingStatus, RegistrationToken, Realm, Realms, Identity, ClientInfo, ClientInfoList, Role, Group, RoleMapping, } = require('./types');
 const Refresher = require('./api/refresher');
 const Token = require('./api/token');
 const BasicIdentity = require('./types/basicIdentity');
@@ -376,6 +376,19 @@ class Client {
         return __awaiter(this, void 0, void 0, function* () {
             const rawResponse = yield this.api.listRealmRoles(this.queenClient, realmName);
             return rawResponse.map(Role.decode);
+        });
+    }
+    /**
+     * Gets realm & client roles that are mapped to a particular realm group.
+     *
+     * @param {string} realmName  Name of realm.
+     * @param {string} groupId    Id of group for which to list role mappings.
+     * @returns {Promise<Role[]>} List of all roles at realm.
+     */
+    listGroupRoleMappings(realmName, groupId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const rawResponse = yield this.api.listGroupRoleMappings(this.queenClient, realmName, groupId);
+            return RoleMapping.decode(rawResponse);
         });
     }
     /**

--- a/dist/client.js
+++ b/dist/client.js
@@ -396,7 +396,7 @@ class Client {
      *
      * @param {string} realmName Name of realm.
      * @param {string} groupId Id of realm group.
-     * @param {GroupRoleMapping} groupRoleMapping The map of roles.
+     * @param {GroupRoleMapping} groupRoleMapping The map of roles to add to group's mapping.
      * @returns {Promise<boolean>} True if successful
      *
      * @example
@@ -418,6 +418,19 @@ class Client {
     addGroupRoleMappings(realmName, groupId, groupRoleMapping) {
         return __awaiter(this, void 0, void 0, function* () {
             return this.api.addGroupRoleMappings(this.queenClient, realmName, groupId, groupRoleMapping);
+        });
+    }
+    /**
+     * Removes a set of realm/client roles from a group's role mapping.
+     *
+     * @param {string} realmName Name of realm.
+     * @param {string} groupId Id of realm group.
+     * @param {GroupRoleMapping} groupRoleMapping The map of roles to remove to group's mapping.
+     * @returns {Promise<boolean>} True if successful
+     */
+    removeGroupRoleMappings(realmName, groupId, groupRoleMapping) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.api.removeGroupRoleMappings(this.queenClient, realmName, groupId, groupRoleMapping);
         });
     }
     /**

--- a/dist/client.js
+++ b/dist/client.js
@@ -392,6 +392,35 @@ class Client {
         });
     }
     /**
+     * Adds a set of realm/client roles to a group's role mapping
+     *
+     * @param {string} realmName Name of realm.
+     * @param {string} groupId Id of realm group.
+     * @param {GroupRoleMapping} groupRoleMapping The map of roles.
+     * @returns {Promise<boolean>} True if successful
+     *
+     * @example
+     * const realmName = 'kitchen'
+     * const chefGroup = await client.createRealmGroup(realmName, { name: 'Chefs' })
+     * const fridgeAccessRole = await client.createRealmRole(realmName, {
+     *   name: 'FridgeAccess',
+     *   description: 'Grants access to the secrets of the fridge.',
+     * })
+     *
+     * // map the "Chefs" realm group to the "FridgeAccess" realm role
+     * // returns true on success
+     * await client.addGroupRoleMappings(
+     *   realmName,
+     *   chefGroup.id,
+     *   { realm: [fridgeAccessRole] }
+     * )
+     */
+    addGroupRoleMappings(realmName, groupId, groupRoleMapping) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.api.addGroupRoleMappings(this.queenClient, realmName, groupId, groupRoleMapping);
+        });
+    }
+    /**
      * registerRealmBrokerIdentity registers an identity to be the broker for a realm.
      * @param  {string} realmName         The name of the realm to register the broker identity with.
      * @param  {string} registrationToken A registration for the account that has permissions for registering clients of type broker.

--- a/dist/client.js
+++ b/dist/client.js
@@ -11,7 +11,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 const { validateStorageClient } = require('./utils');
 const API = require('./api').default;
 const { KEY_HASH_ROUNDS } = require('./utils/constants');
-const { AccountBillingStatus, RegistrationToken, Realm, Realms, Identity, ClientInfo, ClientInfoList, Role, Group, RoleMapping, } = require('./types');
+const { AccountBillingStatus, RegistrationToken, Realm, Realms, Identity, ClientInfo, ClientInfoList, Role, Group, GroupRoleMapping, } = require('./types');
 const Refresher = require('./api/refresher');
 const Token = require('./api/token');
 const BasicIdentity = require('./types/basicIdentity');
@@ -381,14 +381,14 @@ class Client {
     /**
      * Gets realm & client roles that are mapped to a particular realm group.
      *
-     * @param {string} realmName  Name of realm.
-     * @param {string} groupId    Id of group for which to list role mappings.
-     * @returns {Promise<Role[]>} List of all roles at realm.
+     * @param {string} realmName            Name of realm.
+     * @param {string} groupId              Id of group for which to list role mappings.
+     * @returns {Promise<GroupRoleMapping>} List of all roles at realm.
      */
     listGroupRoleMappings(realmName, groupId) {
         return __awaiter(this, void 0, void 0, function* () {
             const rawResponse = yield this.api.listGroupRoleMappings(this.queenClient, realmName, groupId);
-            return RoleMapping.decode(rawResponse);
+            return GroupRoleMapping.decode(rawResponse);
         });
     }
     /**

--- a/dist/types/detailedIdentity.js
+++ b/dist/types/detailedIdentity.js
@@ -1,6 +1,6 @@
 "use strict";
 const Group = require('./group').default;
-const RoleMapping = require('./roleMapping').default;
+const GroupRoleMapping = require('./groupRoleMapping').default;
 /**
  * Detailed information about a registered Identity for a Tozny realm.
  */
@@ -73,7 +73,7 @@ class DetailedIdentity {
      * @return {<DetailedIdentity>}
      */
     static decode(json) {
-        return new DetailedIdentity(json.subject_id, json.username, json.email, json.first_name, json.last_name, json.active, json.federated, RoleMapping.decode(json.roles), Array.isArray(json.groups) ? json.groups.map(Group.decode) : [], typeof json.attributes === 'object' ? json.attributes : {});
+        return new DetailedIdentity(json.subject_id, json.username, json.email, json.first_name, json.last_name, json.active, json.federated, GroupRoleMapping.decode(json.roles), Array.isArray(json.groups) ? json.groups.map(Group.decode) : [], typeof json.attributes === 'object' ? json.attributes : {});
     }
 }
 module.exports = DetailedIdentity;

--- a/dist/types/detailedIdentity.js
+++ b/dist/types/detailedIdentity.js
@@ -1,6 +1,6 @@
 "use strict";
 const Group = require('./group').default;
-const RoleMapping = require('./roleMapping');
+const RoleMapping = require('./roleMapping').default;
 /**
  * Detailed information about a registered Identity for a Tozny realm.
  */

--- a/dist/types/groupRoleMapping.js
+++ b/dist/types/groupRoleMapping.js
@@ -5,14 +5,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const role_1 = __importDefault(require("./role"));
 /**
- * A full set of roles for a realm and client applications in the realm.
+ * An object representing the realm & client roles to which a particular realm group maps.
  */
-class RoleMapping {
-    constructor(realm, clients) {
-        this.realm = realm;
-        // NOTE: this is different from Tozny's API property.
-        // keeping for backwards-compatibility
-        this.clients = clients;
+class GroupRoleMapping {
+    constructor(realmRoles, rolesByClient) {
+        this.realm = realmRoles;
+        this.client = rolesByClient;
     }
     /**
      * Specify how an already unserialized JSON array should be marshaled into
@@ -44,20 +42,15 @@ class RoleMapping {
      *   }
      * })
      * <code>
-     *
-     * @param {object} json
-     *
-     * @return {<RoleMapping>}
      */
     static decode(json) {
-        const realm = RoleMapping._decodeRoles(json.realm);
-        const clients = {};
-        if (typeof json.client === 'object') {
-            for (let name in json.client) {
-                clients[name] = RoleMapping._decodeRoles(json.client[name]);
-            }
-        }
-        return new RoleMapping(realm, clients);
+        const realmRoles = GroupRoleMapping._decodeRoles(json.realm);
+        const rolesByClient = {};
+        const clientNames = Object.keys(json.client);
+        clientNames.forEach(clientName => {
+            rolesByClient[clientName] = this._decodeRoles(json.client[clientName]);
+        });
+        return new GroupRoleMapping(realmRoles, rolesByClient);
     }
     /**
      * decodes a list of role objects into the correct type
@@ -66,4 +59,4 @@ class RoleMapping {
         return roles.map(role_1.default.decode);
     }
 }
-exports.default = RoleMapping;
+exports.default = GroupRoleMapping;

--- a/dist/types/index.js
+++ b/dist/types/index.js
@@ -14,7 +14,7 @@ const Realm = require('./realm');
 const Realms = require('./realms');
 const RegistrationToken = require('./registrationToken');
 const Role = require('./role').default;
-const RoleMapping = require('./roleMapping').default;
+const GroupRoleMapping = require('./groupRoleMapping').default;
 const Sovereign = require('./sovereign');
 module.exports = {
     AccountBillingStatus,
@@ -29,6 +29,6 @@ module.exports = {
     Realms,
     RegistrationToken,
     Role,
-    RoleMapping,
+    GroupRoleMapping,
     Sovereign,
 };

--- a/dist/types/index.js
+++ b/dist/types/index.js
@@ -14,7 +14,7 @@ const Realm = require('./realm');
 const Realms = require('./realms');
 const RegistrationToken = require('./registrationToken');
 const Role = require('./role').default;
-const RoleMapping = require('./roleMapping');
+const RoleMapping = require('./roleMapping').default;
 const Sovereign = require('./sovereign');
 module.exports = {
     AccountBillingStatus,

--- a/dist/types/roleMapping.js
+++ b/dist/types/roleMapping.js
@@ -1,11 +1,17 @@
 "use strict";
-const Role = require('./role').default;
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const role_1 = __importDefault(require("./role"));
 /**
  * A full set of roles for a realm and client applications in the realm.
  */
 class RoleMapping {
     constructor(realm, clients) {
         this.realm = realm;
+        // NOTE: this is different from Tozny's API property.
+        // keeping for backwards-compatibility
         this.clients = clients;
     }
     /**
@@ -45,22 +51,19 @@ class RoleMapping {
      */
     static decode(json) {
         const realm = RoleMapping._decodeRoles(json.realm);
-        const client = {};
+        const clients = {};
         if (typeof json.client === 'object') {
             for (let name in json.client) {
-                client[name] = RoleMapping._decodeRoles(json.client[name]);
+                clients[name] = RoleMapping._decodeRoles(json.client[name]);
             }
         }
-        return new RoleMapping(realm, client);
+        return new RoleMapping(realm, clients);
     }
     /**
      * decodes a list of role objects into the correct type
-     * @param {Array} roles The list of JSON serialized roles
-     * @return {Array<Role>} The list of role objects
-     *
      */
     static _decodeRoles(roles) {
-        return Array.isArray(roles) ? roles.map(Role.decode) : [];
+        return roles.map(role_1.default.decode);
     }
 }
-module.exports = RoleMapping;
+exports.default = RoleMapping;

--- a/src/__tests__/groupRoleMappings.test.ts
+++ b/src/__tests__/groupRoleMappings.test.ts
@@ -3,6 +3,7 @@ import Account from '../account'
 import Tozny from '@toznysecure/sdk/node'
 import { v4 as uuidv4 } from 'uuid'
 import { cleanupRealms } from './utils'
+import { Role } from '../types'
 
 const accountFactory = new Account(Tozny, process.env.API_URL)
 let client: any = null
@@ -27,15 +28,48 @@ afterAll(async () => {
 })
 
 describe('Group Role Mappings', () => {
-  it('lists group role mappings', async () => {
+  it('adds, lists group role mappings', async () => {
     const group = await client.createRealmGroup(realmName, { name: 'Chefs' })
+    const role1 = await client.createRealmRole(realmName, {
+      name: 'FridgeAccess',
+      description: 'Grants access to the secrets of the fridge.',
+    })
+    const role2 = await client.createRealmRole(realmName, {
+      name: 'StovePowers',
+      description: 'They can turn on the stove.',
+    })
 
+    // there are no mapped roles to start
     const roleMappings = await client.listGroupRoleMappings(realmName, group.id)
-
-    console.log({ roleMappings })
 
     expect(roleMappings.client).toEqual({})
     expect(roleMappings.realm).toBeInstanceOf(Array)
     expect(roleMappings.realm).toHaveLength(0)
+
+    // add a mapping!
+    const addResponse = await client.addGroupRoleMappings(realmName, group.id, {
+      realm: [
+        // use minimal set of inputs
+        { id: role1.id, name: role1.name, description: role1.description },
+        // or a full blown Role
+        role2,
+      ],
+    })
+
+    expect(addResponse).toBeTruthy()
+
+    const mappingsAfterAdd = await client.listGroupRoleMappings(
+      realmName,
+      group.id
+    )
+
+    // now there are mapped roles!
+    expect(mappingsAfterAdd.realm).toHaveLength(2)
+    expect(
+      mappingsAfterAdd.realm.find((r: Role) => r.id === role1.id)
+    ).toMatchObject(role1)
+    expect(
+      mappingsAfterAdd.realm.find((r: Role) => r.id === role2.id)
+    ).toMatchObject(role2)
   })
 })

--- a/src/__tests__/groupRoleMappings.test.ts
+++ b/src/__tests__/groupRoleMappings.test.ts
@@ -1,0 +1,40 @@
+import Account from '../account'
+// @ts-ignore no type defs exist for js-sdk
+import Tozny from '@toznysecure/sdk/node'
+import { v4 as uuidv4 } from 'uuid'
+import { cleanupRealms } from './utils'
+import { Group } from '../types'
+
+const accountFactory = new Account(Tozny, process.env.API_URL)
+let client: any = null
+let realmName: string
+
+beforeAll(async () => {
+  // Create an account to re-use across test cases
+  const seed = uuidv4()
+  const name = `Test Account ${seed}`
+  const email = `test+${seed}@tozny.com`
+  const password = uuidv4()
+  const registration: any = await accountFactory.register(name, email, password)
+  client = registration.client
+
+  realmName = `TestRealm${seed.split('-')[0]}`.toLowerCase()
+  const sovereignName = 'YassQueen'
+  await client.createRealm(realmName, sovereignName)
+})
+
+afterAll(async () => {
+  await cleanupRealms(client)
+})
+
+describe('Group Role Mappings', () => {
+  it('lists group role mappings', async () => {
+    const group = await client.createRealmGroup(realmName, { name: 'Chefs' })
+
+    const roleMappings = await client.listGroupRoleMappings(realmName, group.id)
+
+    expect(roleMappings.clients).toEqual({})
+    expect(roleMappings.realm).toBeInstanceOf(Array)
+    expect(roleMappings.realm).toHaveLength(0)
+  })
+})

--- a/src/__tests__/groupRoleMappings.test.ts
+++ b/src/__tests__/groupRoleMappings.test.ts
@@ -3,7 +3,6 @@ import Account from '../account'
 import Tozny from '@toznysecure/sdk/node'
 import { v4 as uuidv4 } from 'uuid'
 import { cleanupRealms } from './utils'
-import { Group } from '../types'
 
 const accountFactory = new Account(Tozny, process.env.API_URL)
 let client: any = null
@@ -33,7 +32,9 @@ describe('Group Role Mappings', () => {
 
     const roleMappings = await client.listGroupRoleMappings(realmName, group.id)
 
-    expect(roleMappings.clients).toEqual({})
+    console.log({ roleMappings })
+
+    expect(roleMappings.client).toEqual({})
     expect(roleMappings.realm).toBeInstanceOf(Array)
     expect(roleMappings.realm).toHaveLength(0)
   })

--- a/src/__tests__/groupRoleMappings.test.ts
+++ b/src/__tests__/groupRoleMappings.test.ts
@@ -28,7 +28,7 @@ afterAll(async () => {
 })
 
 describe('Group Role Mappings', () => {
-  it('adds, lists group role mappings', async () => {
+  it('adds, lists, removes group role mappings', async () => {
     const group = await client.createRealmGroup(realmName, { name: 'Chefs' })
     const role1 = await client.createRealmRole(realmName, {
       name: 'FridgeAccess',
@@ -71,5 +71,25 @@ describe('Group Role Mappings', () => {
     expect(
       mappingsAfterAdd.realm.find((r: Role) => r.id === role2.id)
     ).toMatchObject(role2)
+
+    // the day chefs lost access to the fridge
+    const removeResponse = await client.removeGroupRoleMappings(
+      realmName,
+      group.id,
+      { realm: [role1] }
+    )
+
+    expect(removeResponse).toBeTruthy()
+
+    const mappingsAfterRemove = await client.listGroupRoleMappings(
+      realmName,
+      group.id
+    )
+
+    expect(mappingsAfterRemove.realm).toHaveLength(1)
+    expect(mappingsAfterRemove.realm[0].id).toEqual(role2.id)
+    expect(mappingsAfterRemove.realm[0].name).toMatchInlineSnapshot(
+      `"StovePowers"`
+    )
   })
 })

--- a/src/__tests__/realm.test.js
+++ b/src/__tests__/realm.test.js
@@ -249,7 +249,7 @@ describe('Account Client', () => {
       expect(idDetails).toBeInstanceOf(DetailedIdentity)
       expect(idDetails.username).toBe(sovereignName.toLowerCase())
       expect(
-        idDetails.roles.clients['realm-management'].map(r => r.name)
+        idDetails.roles.client['realm-management'].map(r => r.name)
       ).toContain('realm-admin')
     } finally {
       await cleanupRealms(client)

--- a/src/api/groupRoleMappings.ts
+++ b/src/api/groupRoleMappings.ts
@@ -42,11 +42,26 @@ type AddRemoveGroupRoleMappingData = {
 export async function addGroupRoleMappings(
   { realmName, groupId, groupRoleMapping }: AddRemoveGroupRoleMappingData,
   { apiUrl, queenClient }: APIContext
-) {
+): Promise<void> {
   const response = await queenClient.authenticator.tsv1Fetch(
     roleMappingForGroupUri(apiUrl, realmName, groupId),
     {
       method: 'POST',
+      body: JSON.stringify(groupRoleMapping),
+    }
+  )
+  checkStatus(response)
+  return
+}
+
+export async function removeGroupRoleMappings(
+  { realmName, groupId, groupRoleMapping }: AddRemoveGroupRoleMappingData,
+  { apiUrl, queenClient }: APIContext
+): Promise<void> {
+  const response = await queenClient.authenticator.tsv1Fetch(
+    roleMappingForGroupUri(apiUrl, realmName, groupId),
+    {
+      method: 'DELETE',
       body: JSON.stringify(groupRoleMapping),
     }
   )

--- a/src/api/groupRoleMappings.ts
+++ b/src/api/groupRoleMappings.ts
@@ -1,0 +1,15 @@
+import { ToznyAPIRoleMapping } from '../types/roleMapping'
+import { validateRequestAsJSON } from '../utils'
+import { APIContext } from './context'
+
+type ListGroupRoleMappingsData = { groupId: string; realmName: string }
+export async function listGroupRoleMappings(
+  { groupId, realmName }: ListGroupRoleMappingsData,
+  { apiUrl, queenClient }: APIContext
+): Promise<ToznyAPIRoleMapping> {
+  const response = await queenClient.authenticator.tsv1Fetch(
+    `${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}/role_mapping`,
+    { method: 'GET' }
+  )
+  return validateRequestAsJSON(response)
+}

--- a/src/api/groupRoleMappings.ts
+++ b/src/api/groupRoleMappings.ts
@@ -1,6 +1,26 @@
 import { ToznyAPIGroupRoleMapping } from '../types/groupRoleMapping'
-import { validateRequestAsJSON } from '../utils'
+import { checkStatus, validateRequestAsJSON } from '../utils'
 import { APIContext } from './context'
+
+/** Minimal set of data required for role info */
+interface RoleData {
+  id: string
+  name: string
+  description: string
+}
+
+/** Minimal set of data required for role mapping input */
+export type GroupRoleMappingInput = {
+  realm?: RoleData[]
+  client?: Record<string, RoleData[]>
+}
+
+const roleMappingForGroupUri = (
+  apiUrl: string,
+  realmName: string,
+  groupId: string
+): String =>
+  `${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}/role_mapping`
 
 type ListGroupRoleMappingsData = { groupId: string; realmName: string }
 export async function listGroupRoleMappings(
@@ -8,8 +28,28 @@ export async function listGroupRoleMappings(
   { apiUrl, queenClient }: APIContext
 ): Promise<ToznyAPIGroupRoleMapping> {
   const response = await queenClient.authenticator.tsv1Fetch(
-    `${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}/role_mapping`,
+    roleMappingForGroupUri(apiUrl, realmName, groupId),
     { method: 'GET' }
   )
   return validateRequestAsJSON(response)
+}
+
+type AddRemoveGroupRoleMappingData = {
+  realmName: string
+  groupId: string
+  groupRoleMapping: GroupRoleMappingInput
+}
+export async function addGroupRoleMappings(
+  { realmName, groupId, groupRoleMapping }: AddRemoveGroupRoleMappingData,
+  { apiUrl, queenClient }: APIContext
+) {
+  const response = await queenClient.authenticator.tsv1Fetch(
+    roleMappingForGroupUri(apiUrl, realmName, groupId),
+    {
+      method: 'POST',
+      body: JSON.stringify(groupRoleMapping),
+    }
+  )
+  checkStatus(response)
+  return
 }

--- a/src/api/groupRoleMappings.ts
+++ b/src/api/groupRoleMappings.ts
@@ -1,4 +1,4 @@
-import { ToznyAPIRoleMapping } from '../types/roleMapping'
+import { ToznyAPIGroupRoleMapping } from '../types/groupRoleMapping'
 import { validateRequestAsJSON } from '../utils'
 import { APIContext } from './context'
 
@@ -6,7 +6,7 @@ type ListGroupRoleMappingsData = { groupId: string; realmName: string }
 export async function listGroupRoleMappings(
   { groupId, realmName }: ListGroupRoleMappingsData,
   { apiUrl, queenClient }: APIContext
-): Promise<ToznyAPIRoleMapping> {
+): Promise<ToznyAPIGroupRoleMapping> {
   const response = await queenClient.authenticator.tsv1Fetch(
     `${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}/role_mapping`,
     { method: 'GET' }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,7 +20,7 @@ import {
   describeRealmGroup,
   listRealmGroups,
 } from './realmGroups'
-import { ToznyAPIRoleMapping } from '../types/roleMapping'
+import { ToznyAPIGroupRoleMapping } from '../types/groupRoleMapping'
 import { listGroupRoleMappings } from './groupRoleMappings'
 
 // this is a placeholder until we have real types from js-sdk
@@ -764,7 +764,7 @@ class API {
     queenClient: ToznyClient,
     realmName: string,
     groupId: string
-  ): Promise<ToznyAPIRoleMapping[]> {
+  ): Promise<ToznyAPIGroupRoleMapping> {
     return listGroupRoleMappings(
       { groupId, realmName },
       { apiUrl: this.apiUrl, queenClient }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,8 +20,14 @@ import {
   describeRealmGroup,
   listRealmGroups,
 } from './realmGroups'
-import { ToznyAPIGroupRoleMapping } from '../types/groupRoleMapping'
-import { listGroupRoleMappings } from './groupRoleMappings'
+import GroupRoleMapping, {
+  ToznyAPIGroupRoleMapping,
+} from '../types/groupRoleMapping'
+import {
+  addGroupRoleMappings,
+  GroupRoleMappingInput,
+  listGroupRoleMappings,
+} from './groupRoleMappings'
 
 // this is a placeholder until we have real types from js-sdk
 type ToznyClient = any
@@ -769,6 +775,22 @@ class API {
       { groupId, realmName },
       { apiUrl: this.apiUrl, queenClient }
     )
+  }
+
+  /**
+   * Maps a particular realm group to a set of realm & client roles.
+   */
+  async addGroupRoleMappings(
+    queenClient: ToznyClient,
+    realmName: string,
+    groupId: string,
+    groupRoleMapping: GroupRoleMappingInput
+  ): Promise<boolean> {
+    await addGroupRoleMappings(
+      { realmName, groupId, groupRoleMapping },
+      { apiUrl: this.apiUrl, queenClient }
+    )
+    return true
   }
 
   /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,6 +20,8 @@ import {
   describeRealmGroup,
   listRealmGroups,
 } from './realmGroups'
+import { ToznyAPIRoleMapping } from '../types/roleMapping'
+import { listGroupRoleMappings } from './groupRoleMappings'
 
 // this is a placeholder until we have real types from js-sdk
 type ToznyClient = any
@@ -753,6 +755,20 @@ class API {
     realmName: string
   ): Promise<ToznyAPIRole[]> {
     return listRealmRoles({ realmName }, { apiUrl: this.apiUrl, queenClient })
+  }
+
+  /**
+   * Gets realm & client roles that are mapped to a particular realm group.
+   */
+  async listGroupRoleMappings(
+    queenClient: ToznyClient,
+    realmName: string,
+    groupId: string
+  ): Promise<ToznyAPIRoleMapping[]> {
+    return listGroupRoleMappings(
+      { groupId, realmName },
+      { apiUrl: this.apiUrl, queenClient }
+    )
   }
 
   /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,6 +27,7 @@ import {
   addGroupRoleMappings,
   GroupRoleMappingInput,
   listGroupRoleMappings,
+  removeGroupRoleMappings,
 } from './groupRoleMappings'
 
 // this is a placeholder until we have real types from js-sdk
@@ -787,6 +788,22 @@ class API {
     groupRoleMapping: GroupRoleMappingInput
   ): Promise<boolean> {
     await addGroupRoleMappings(
+      { realmName, groupId, groupRoleMapping },
+      { apiUrl: this.apiUrl, queenClient }
+    )
+    return true
+  }
+
+  /**
+   * Removes a set of realm/client roles from a group's role mapping.
+   */
+  async removeGroupRoleMappings(
+    queenClient: ToznyClient,
+    realmName: string,
+    groupId: string,
+    groupRoleMapping: GroupRoleMappingInput
+  ): Promise<boolean> {
+    await removeGroupRoleMappings(
       { realmName, groupId, groupRoleMapping },
       { apiUrl: this.apiUrl, queenClient }
     )

--- a/src/api/realmGroups.ts
+++ b/src/api/realmGroups.ts
@@ -38,7 +38,7 @@ type DescribeRealmGroupData = { realmName: string; groupId: string }
 export async function describeRealmGroup(
   { realmName, groupId }: DescribeRealmGroupData,
   { apiUrl, queenClient }: APIContext
-): Promise<void> {
+): Promise<ToznyAPIGroup> {
   const response = await queenClient.authenticator.tsv1Fetch(
     `${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}`,
     { method: 'GET' }

--- a/src/client.js
+++ b/src/client.js
@@ -436,6 +436,39 @@ class Client {
   }
 
   /**
+   * Adds a set of realm/client roles to a group's role mapping
+   *
+   * @param {string} realmName Name of realm.
+   * @param {string} groupId Id of realm group.
+   * @param {GroupRoleMapping} groupRoleMapping The map of roles.
+   * @returns {Promise<boolean>} True if successful
+   *
+   * @example
+   * const realmName = 'kitchen'
+   * const chefGroup = await client.createRealmGroup(realmName, { name: 'Chefs' })
+   * const fridgeAccessRole = await client.createRealmRole(realmName, {
+   *   name: 'FridgeAccess',
+   *   description: 'Grants access to the secrets of the fridge.',
+   * })
+   *
+   * // map the "Chefs" realm group to the "FridgeAccess" realm role
+   * // returns true on success
+   * await client.addGroupRoleMappings(
+   *   realmName,
+   *   chefGroup.id,
+   *   { realm: [fridgeAccessRole] }
+   * )
+   */
+  async addGroupRoleMappings(realmName, groupId, groupRoleMapping) {
+    return this.api.addGroupRoleMappings(
+      this.queenClient,
+      realmName,
+      groupId,
+      groupRoleMapping
+    )
+  }
+
+  /**
    * registerRealmBrokerIdentity registers an identity to be the broker for a realm.
    * @param  {string} realmName         The name of the realm to register the broker identity with.
    * @param  {string} registrationToken A registration for the account that has permissions for registering clients of type broker.

--- a/src/client.js
+++ b/src/client.js
@@ -440,7 +440,7 @@ class Client {
    *
    * @param {string} realmName Name of realm.
    * @param {string} groupId Id of realm group.
-   * @param {GroupRoleMapping} groupRoleMapping The map of roles.
+   * @param {GroupRoleMapping} groupRoleMapping The map of roles to add to group's mapping.
    * @returns {Promise<boolean>} True if successful
    *
    * @example
@@ -461,6 +461,23 @@ class Client {
    */
   async addGroupRoleMappings(realmName, groupId, groupRoleMapping) {
     return this.api.addGroupRoleMappings(
+      this.queenClient,
+      realmName,
+      groupId,
+      groupRoleMapping
+    )
+  }
+
+  /**
+   * Removes a set of realm/client roles from a group's role mapping.
+   *
+   * @param {string} realmName Name of realm.
+   * @param {string} groupId Id of realm group.
+   * @param {GroupRoleMapping} groupRoleMapping The map of roles to remove to group's mapping.
+   * @returns {Promise<boolean>} True if successful
+   */
+  async removeGroupRoleMappings(realmName, groupId, groupRoleMapping) {
+    return this.api.removeGroupRoleMappings(
       this.queenClient,
       realmName,
       groupId,

--- a/src/client.js
+++ b/src/client.js
@@ -11,7 +11,7 @@ const {
   ClientInfoList,
   Role,
   Group,
-  RoleMapping,
+  GroupRoleMapping,
 } = require('./types')
 const Refresher = require('./api/refresher')
 const Token = require('./api/token')
@@ -422,9 +422,9 @@ class Client {
   /**
    * Gets realm & client roles that are mapped to a particular realm group.
    *
-   * @param {string} realmName  Name of realm.
-   * @param {string} groupId    Id of group for which to list role mappings.
-   * @returns {Promise<Role[]>} List of all roles at realm.
+   * @param {string} realmName            Name of realm.
+   * @param {string} groupId              Id of group for which to list role mappings.
+   * @returns {Promise<GroupRoleMapping>} List of all roles at realm.
    */
   async listGroupRoleMappings(realmName, groupId) {
     const rawResponse = await this.api.listGroupRoleMappings(
@@ -432,7 +432,7 @@ class Client {
       realmName,
       groupId
     )
-    return RoleMapping.decode(rawResponse)
+    return GroupRoleMapping.decode(rawResponse)
   }
 
   /**

--- a/src/client.js
+++ b/src/client.js
@@ -11,6 +11,7 @@ const {
   ClientInfoList,
   Role,
   Group,
+  RoleMapping,
 } = require('./types')
 const Refresher = require('./api/refresher')
 const Token = require('./api/token')
@@ -416,6 +417,22 @@ class Client {
       realmName
     )
     return rawResponse.map(Role.decode)
+  }
+
+  /**
+   * Gets realm & client roles that are mapped to a particular realm group.
+   *
+   * @param {string} realmName  Name of realm.
+   * @param {string} groupId    Id of group for which to list role mappings.
+   * @returns {Promise<Role[]>} List of all roles at realm.
+   */
+  async listGroupRoleMappings(realmName, groupId) {
+    const rawResponse = await this.api.listGroupRoleMappings(
+      this.queenClient,
+      realmName,
+      groupId
+    )
+    return RoleMapping.decode(rawResponse)
   }
 
   /**

--- a/src/types/detailedIdentity.js
+++ b/src/types/detailedIdentity.js
@@ -1,5 +1,5 @@
 const Group = require('./group').default
-const RoleMapping = require('./roleMapping')
+const RoleMapping = require('./roleMapping').default
 
 /**
  * Detailed information about a registered Identity for a Tozny realm.

--- a/src/types/detailedIdentity.js
+++ b/src/types/detailedIdentity.js
@@ -1,5 +1,5 @@
 const Group = require('./group').default
-const RoleMapping = require('./roleMapping').default
+const GroupRoleMapping = require('./groupRoleMapping').default
 
 /**
  * Detailed information about a registered Identity for a Tozny realm.
@@ -93,7 +93,7 @@ class DetailedIdentity {
       json.last_name,
       json.active,
       json.federated,
-      RoleMapping.decode(json.roles),
+      GroupRoleMapping.decode(json.roles),
       Array.isArray(json.groups) ? json.groups.map(Group.decode) : [],
       typeof json.attributes === 'object' ? json.attributes : {}
     )

--- a/src/types/groupRoleMapping.ts
+++ b/src/types/groupRoleMapping.ts
@@ -1,18 +1,18 @@
 import Role, { ToznyAPIRole } from './role'
 
-type ClientRoles = Record<string, Role[]>
+type RolesByClient = Record<string, Role[]>
 
 /**
- * A full set of roles for a realm and client applications in the realm.
+ * An object representing the realm & client roles to which a particular realm group maps.
  */
-class RoleMapping {
+class GroupRoleMapping {
+  /** Realm roles to which the group maps. */
   realm: Role[]
-  clients: ClientRoles
-  constructor(realm: Role[], clients: ClientRoles) {
-    this.realm = realm
-    // NOTE: this is different from Tozny's API property.
-    // keeping for backwards-compatibility
-    this.clients = clients
+  /** A map of client names to roles to which this group maps. */
+  client: RolesByClient
+  constructor(realmRoles: Role[], rolesByClient: RolesByClient) {
+    this.realm = realmRoles
+    this.client = rolesByClient
   }
 
   /**
@@ -45,20 +45,17 @@ class RoleMapping {
    *   }
    * })
    * <code>
-   *
-   * @param {object} json
-   *
-   * @return {<RoleMapping>}
    */
-  static decode(json: ToznyAPIRoleMapping): RoleMapping {
-    const realm = RoleMapping._decodeRoles(json.realm)
-    const clients: ClientRoles = {}
-    if (typeof json.client === 'object') {
-      for (let name in json.client) {
-        clients[name] = RoleMapping._decodeRoles(json.client[name])
-      }
-    }
-    return new RoleMapping(realm, clients)
+  static decode(json: ToznyAPIGroupRoleMapping): GroupRoleMapping {
+    const realmRoles = GroupRoleMapping._decodeRoles(json.realm)
+
+    const rolesByClient: RolesByClient = {}
+    const clientNames = Object.keys(json.client)
+    clientNames.forEach(clientName => {
+      rolesByClient[clientName] = this._decodeRoles(json.client[clientName])
+    })
+
+    return new GroupRoleMapping(realmRoles, rolesByClient)
   }
 
   /**
@@ -69,9 +66,9 @@ class RoleMapping {
   }
 }
 
-export type ToznyAPIRoleMapping = {
+export type ToznyAPIGroupRoleMapping = {
   realm: ToznyAPIRole[]
   client: Record<string, ToznyAPIRole[]>
 }
 
-export default RoleMapping
+export default GroupRoleMapping

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -14,7 +14,7 @@ const Realm = require('./realm')
 const Realms = require('./realms')
 const RegistrationToken = require('./registrationToken')
 const Role = require('./role').default
-const RoleMapping = require('./roleMapping')
+const RoleMapping = require('./roleMapping').default
 const Sovereign = require('./sovereign')
 
 module.exports = {

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -14,7 +14,7 @@ const Realm = require('./realm')
 const Realms = require('./realms')
 const RegistrationToken = require('./registrationToken')
 const Role = require('./role').default
-const RoleMapping = require('./roleMapping').default
+const GroupRoleMapping = require('./groupRoleMapping').default
 const Sovereign = require('./sovereign')
 
 module.exports = {
@@ -30,6 +30,6 @@ module.exports = {
   Realms,
   RegistrationToken,
   Role,
-  RoleMapping,
+  GroupRoleMapping,
   Sovereign,
 }

--- a/src/types/roleMapping.ts
+++ b/src/types/roleMapping.ts
@@ -1,11 +1,17 @@
-const Role = require('./role').default
+import Role, { ToznyAPIRole } from './role'
+
+type ClientRoles = Record<string, Role[]>
 
 /**
  * A full set of roles for a realm and client applications in the realm.
  */
 class RoleMapping {
-  constructor(realm, clients) {
+  realm: Role[]
+  clients: ClientRoles
+  constructor(realm: Role[], clients: ClientRoles) {
     this.realm = realm
+    // NOTE: this is different from Tozny's API property.
+    // keeping for backwards-compatibility
     this.clients = clients
   }
 
@@ -44,26 +50,28 @@ class RoleMapping {
    *
    * @return {<RoleMapping>}
    */
-  static decode(json) {
+  static decode(json: ToznyAPIRoleMapping): RoleMapping {
     const realm = RoleMapping._decodeRoles(json.realm)
-    const client = {}
+    const clients: ClientRoles = {}
     if (typeof json.client === 'object') {
       for (let name in json.client) {
-        client[name] = RoleMapping._decodeRoles(json.client[name])
+        clients[name] = RoleMapping._decodeRoles(json.client[name])
       }
     }
-    return new RoleMapping(realm, client)
+    return new RoleMapping(realm, clients)
   }
 
   /**
    * decodes a list of role objects into the correct type
-   * @param {Array} roles The list of JSON serialized roles
-   * @return {Array<Role>} The list of role objects
-   *
    */
-  static _decodeRoles(roles) {
-    return Array.isArray(roles) ? roles.map(Role.decode) : []
+  static _decodeRoles(roles: ToznyAPIRole[]): Role[] {
+    return roles.map(Role.decode)
   }
 }
 
-module.exports = RoleMapping
+export type ToznyAPIRoleMapping = {
+  realm: ToznyAPIRole[]
+  client: Record<string, ToznyAPIRole[]>
+}
+
+export default RoleMapping


### PR DESCRIPTION
* adds `list`, `add`, `remove` methods for `GroupRoleMappings`
* moved & updated the `roleMapping` type to `groupRoleMapping`
* proud of my tests that reflect a world in which chefs with access to the fridge and stove lose their fridge access. 👨‍🍳 😆 

Please disregard reviewing compiled code in `dist`.

## Minor Breaking API Change
The previous `RoleMapping` class (now `GroupRoleMapping`) was publicly exposed by way of `DetailedIdentity.roles`. A commit in this PR contains a property name change `clients` -> `client` to match Tozny's API response type. `DetailedIdentity` is returned by the client's `identityDetails` method. As such, a migration would be necessary if one made use of `DetailedIdentity.role.clients`. The property is now `client`.
