### PR TITLE
lint & typecheck on precommit for ts files

### DIFF
--- a/dist/api/realmApplicationRoles.js
+++ b/dist/api/realmApplicationRoles.js
@@ -22,7 +22,7 @@ function createRealmApplicationRole({ realmName, applicationId, role }, { apiUrl
     });
 }
 exports.createRealmApplicationRole = createRealmApplicationRole;
-function updateRealmApplicationRole({ realmName, applicationId, originalRoleName, role }, { apiUrl, queenClient }) {
+function updateRealmApplicationRole({ realmName, applicationId, originalRoleName, role, }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const encodedRoleName = encodeURIComponent(originalRoleName);
         const uri = `${realmApplicationRoleUri(apiUrl, realmName, applicationId)}/${encodedRoleName}`;
@@ -38,7 +38,9 @@ function deleteRealmApplicationRole({ realmName, applicationId, roleName }, { ap
     return __awaiter(this, void 0, void 0, function* () {
         const encodedRoleName = encodeURIComponent(roleName);
         const uri = `${realmApplicationRoleUri(apiUrl, realmName, applicationId)}/${encodedRoleName}`;
-        const response = yield queenClient.authenticator.tsv1Fetch(uri, { method: 'DELETE' });
+        const response = yield queenClient.authenticator.tsv1Fetch(uri, {
+            method: 'DELETE',
+        });
         utils_1.checkStatus(response);
         return;
     });
@@ -48,7 +50,9 @@ function describeRealmApplicationRole({ realmName, applicationId, roleName }, { 
     return __awaiter(this, void 0, void 0, function* () {
         const encodedRoleName = encodeURIComponent(roleName);
         const uri = `${realmApplicationRoleUri(apiUrl, realmName, applicationId)}/${encodedRoleName}`;
-        const response = yield queenClient.authenticator.tsv1Fetch(uri, { method: 'GET' });
+        const response = yield queenClient.authenticator.tsv1Fetch(uri, {
+            method: 'GET',
+        });
         return utils_1.validateRequestAsJSON(response);
     });
 }

--- a/dist/types/clientInfoList.js
+++ b/dist/types/clientInfoList.js
@@ -38,7 +38,7 @@ class ClientInfoList {
      */
     static decode(json) {
         let clients = json.clients
-            ? [...json.clients].map((c) => ClientInfo.decode(c))
+            ? [...json.clients].map(c => ClientInfo.decode(c))
             : [];
         return new ClientInfoList(clients, json.next_token);
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -fr dist && tsc",
     "test": "jest",
-    "prettier": "prettier --write src/**/*.js",
+    "prettier": "prettier --write src/**/*.{js,ts}",
     "tp": "./scripts/tozny_platform.sh",
     "typecheck": "tsc --noEmit"
   },
@@ -69,7 +69,11 @@
   "lint-staged": {
     "*.js": [
       "eslint --fix",
-      "git add"
+      "prettier --write"
+    ],
+    "*.ts": [
+      "npm run typecheck",
+      "prettier --write"
     ]
   }
 }

--- a/src/__tests__/realmGroups.test.ts
+++ b/src/__tests__/realmGroups.test.ts
@@ -33,8 +33,8 @@ describe('Realm Groups', () => {
       name: 'Admins',
       attributes: {
         key1: 'value1',
-        key2: 'value2'
-      }
+        key2: 'value2',
+      },
     })
 
     expect(adminGroup.id).toBeTruthy()
@@ -50,13 +50,17 @@ describe('Realm Groups', () => {
     expect(groups[0].name).toBe('Admins')
 
     // updates a group
-    const updatedGroup = await client.updateRealmGroup(realmName, adminGroup.id, {
-      name: 'Updated',
-      attributes: {
-        key2: 'updated',
-        key3: 'new',
+    const updatedGroup = await client.updateRealmGroup(
+      realmName,
+      adminGroup.id,
+      {
+        name: 'Updated',
+        attributes: {
+          key2: 'updated',
+          key3: 'new',
+        },
       }
-    })
+    )
 
     expect(updatedGroup.name).toBe('Updated')
     expect(updatedGroup.attributes.key1).toBeUndefined()
@@ -100,15 +104,21 @@ describe('Realm Groups', () => {
       name: 'With',
       attributes: {
         key1: 'value1',
-        key2: 'value2'
-      }
+        key2: 'value2',
+      },
     })
 
-    const withoutAttributes = await client.describeRealmGroup(realmName, createdWithoutAttributes.id)
-    const withAttributes = await client.describeRealmGroup(realmName, createdWithAttributes.id)
+    const withoutAttributes = await client.describeRealmGroup(
+      realmName,
+      createdWithoutAttributes.id
+    )
+    const withAttributes = await client.describeRealmGroup(
+      realmName,
+      createdWithAttributes.id
+    )
 
     expect(withoutAttributes.attributes).toStrictEqual({})
-    expect(withAttributes.attributes).toMatchObject({ key1: 'value1'})
-    expect(withAttributes.attributes).toMatchObject({ key2: 'value2'})
+    expect(withAttributes.attributes).toMatchObject({ key1: 'value1' })
+    expect(withAttributes.attributes).toMatchObject({ key2: 'value2' })
   })
 })

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -698,7 +698,7 @@ class API {
   /**
    * Updates an existing group for the requested realm.
    */
-   async updateRealmGroup(
+  async updateRealmGroup(
     queenClient: ToznyClient,
     realmName: string,
     groupId: string,
@@ -766,10 +766,10 @@ class API {
   /**
    * Updates an existing role for the requested realm.
    */
-   async updateRealmRole(
+  async updateRealmRole(
     queenClient: ToznyClient,
     realmName: string,
-    role: { name: string, description: string }
+    role: { name: string; description: string }
   ): Promise<ToznyAPIRole> {
     return updateRealmRole(
       { realmName, role },
@@ -834,12 +834,12 @@ class API {
   /**
    * Updates an existing application role for the requested realm.
    */
-   async updateRealmApplicationRole(
+  async updateRealmApplicationRole(
     queenClient: ToznyClient,
     realmName: string,
     applicationId: string,
     originalRoleName: string,
-    role: { name: string, description: string }
+    role: { name: string; description: string }
   ): Promise<ToznyAPIRole> {
     return updateRealmApplicationRole(
       { realmName, applicationId, originalRoleName, role },

--- a/src/api/realmApplicationRoles.ts
+++ b/src/api/realmApplicationRoles.ts
@@ -32,20 +32,27 @@ type UpdateRealmApplicationRoleData = {
   realmName: string
   applicationId: string
   originalRoleName: string
-  role: { id: string, name: string, description: string }
+  role: { id: string; name: string; description: string }
 }
 export async function updateRealmApplicationRole(
-  { realmName, applicationId, originalRoleName, role }: UpdateRealmApplicationRoleData,
+  {
+    realmName,
+    applicationId,
+    originalRoleName,
+    role,
+  }: UpdateRealmApplicationRoleData,
   { apiUrl, queenClient }: APIContext
 ): Promise<ToznyAPIRole> {
   const encodedRoleName = encodeURIComponent(originalRoleName)
-  const uri = `${realmApplicationRoleUri(apiUrl, realmName, applicationId)}/${encodedRoleName}`
-  const response = await queenClient.authenticator.tsv1Fetch(uri,
-    {
-      method: 'PUT',
-      body: JSON.stringify(role),
-    }
-  )
+  const uri = `${realmApplicationRoleUri(
+    apiUrl,
+    realmName,
+    applicationId
+  )}/${encodedRoleName}`
+  const response = await queenClient.authenticator.tsv1Fetch(uri, {
+    method: 'PUT',
+    body: JSON.stringify(role),
+  })
   return validateRequestAsJSON(response)
 }
 
@@ -59,8 +66,14 @@ export async function deleteRealmApplicationRole(
   { apiUrl, queenClient }: APIContext
 ): Promise<void> {
   const encodedRoleName = encodeURIComponent(roleName)
-  const uri = `${realmApplicationRoleUri(apiUrl, realmName, applicationId)}/${encodedRoleName}`
-  const response = await queenClient.authenticator.tsv1Fetch(uri, { method: 'DELETE' })
+  const uri = `${realmApplicationRoleUri(
+    apiUrl,
+    realmName,
+    applicationId
+  )}/${encodedRoleName}`
+  const response = await queenClient.authenticator.tsv1Fetch(uri, {
+    method: 'DELETE',
+  })
   checkStatus(response)
   return
 }
@@ -75,8 +88,14 @@ export async function describeRealmApplicationRole(
   { apiUrl, queenClient }: APIContext
 ): Promise<ToznyAPIRole> {
   const encodedRoleName = encodeURIComponent(roleName)
-  const uri = `${realmApplicationRoleUri(apiUrl, realmName, applicationId)}/${encodedRoleName}`
-  const response = await queenClient.authenticator.tsv1Fetch(uri, { method: 'GET' })
+  const uri = `${realmApplicationRoleUri(
+    apiUrl,
+    realmName,
+    applicationId
+  )}/${encodedRoleName}`
+  const response = await queenClient.authenticator.tsv1Fetch(uri, {
+    method: 'GET',
+  })
   return validateRequestAsJSON(response)
 }
 

--- a/src/api/realmRoles.ts
+++ b/src/api/realmRoles.ts
@@ -23,7 +23,7 @@ export async function createRealmRole(
 
 type UpdateRealmRoleData = {
   realmName: string
-  role: { id: string, name: string, description: string }
+  role: { id: string; name: string; description: string }
 }
 export async function updateRealmRole(
   { realmName, role }: UpdateRealmRoleData,

--- a/src/types/clientInfoList.js
+++ b/src/types/clientInfoList.js
@@ -39,7 +39,7 @@ class ClientInfoList {
    */
   static decode(json) {
     let clients = json.clients
-      ? [...json.clients].map((c) => ClientInfo.decode(c))
+      ? [...json.clients].map(c => ClientInfo.decode(c))
       : []
     return new ClientInfoList(clients, json.next_token)
   }

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -9,7 +9,13 @@ class Group {
   path: string
   attributes?: RealmGroupAttributes
   subGroups: string[]
-  constructor(id: string, name: string, path: string, attributes: RealmGroupAttributes, subGroups: string[]) {
+  constructor(
+    id: string,
+    name: string,
+    path: string,
+    attributes: RealmGroupAttributes,
+    subGroups: string[]
+  ) {
     this.id = id
     this.name = name
     this.path = path
@@ -38,7 +44,13 @@ class Group {
   static decode(json: ToznyAPIGroup): Group {
     const attributes = transformAttributes(json.attributes || {})
 
-    return new Group(json.id, json.name, json.path, attributes, json.subGroups || [])
+    return new Group(
+      json.id,
+      json.name,
+      json.path,
+      attributes,
+      json.subGroups || []
+    )
   }
 }
 


### PR DESCRIPTION
* includes typescript files when running `npm run prettier`
* adds pre-commit hook for typechecking & linting typescript files

when it fails it looks like:
![Screen Shot 2021-09-28 at 9 56 14 AM](https://user-images.githubusercontent.com/14897503/135131810-83d1557d-8886-41a6-83ac-9d72be9c5691.png)
and it lists the failing typechecks  & prevents commit (can be bypassed with `--no-verify`)

when it passes it looks like:
![Screen Shot 2021-09-28 at 9 57 10 AM](https://user-images.githubusercontent.com/14897503/135131932-ca2690cb-cbb7-4916-b3ad-c7b7c94df591.png)

