### PR TITLE
[COZ-751] add tozny_id to DetailedIdentity 

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,8 +375,11 @@ const identityResponse = await accountClient.registerIdentity(
 **Delete Identity from Realm**
 
 ```js
+// Get the identityId you wish to delete
+const identity = accountClient.identityDetails(realmName, username)
+
 // Delete identity
-await accountClient.deleteIdentity(realmName, identityId)
+await accountClient.deleteIdentity(realmName, identity.toznyId)
 ```
 
 **Get details about an identity in a realm**

--- a/dist/types/detailedIdentity.js
+++ b/dist/types/detailedIdentity.js
@@ -5,8 +5,9 @@ const GroupRoleMapping = require('./groupRoleMapping').default;
  * Detailed information about a registered Identity for a Tozny realm.
  */
 class DetailedIdentity {
-    constructor(id, username, email, firstName, lastName, active, federated, roles, groups, attributes) {
+    constructor(id, username, email, firstName, lastName, active, federated, roles, groups, attributes, tozny_id) {
         this.id = id;
+        this.toznyId = tozny_id;
         this.username = username;
         this.email = email;
         this.firstName = firstName;
@@ -24,6 +25,7 @@ class DetailedIdentity {
      * <code>
      * identity = DetailedIdentity::decode({
      *   id: '00000000-0000-0000-0000-000000000000',
+     *   tozny_id: '00000000-0000-0000-0000-000000000000',
      *   name: 'jsmith',
      *   email: 'jsmith@example.com'
      *   first_name: 'John',
@@ -73,7 +75,7 @@ class DetailedIdentity {
      * @return {<DetailedIdentity>}
      */
     static decode(json) {
-        return new DetailedIdentity(json.subject_id, json.username, json.email, json.first_name, json.last_name, json.active, json.federated, GroupRoleMapping.decode(json.roles), Array.isArray(json.groups) ? json.groups.map(Group.decode) : [], typeof json.attributes === 'object' ? json.attributes : {});
+        return new DetailedIdentity(json.subject_id, json.username, json.email, json.first_name, json.last_name, json.active, json.federated, GroupRoleMapping.decode(json.roles), Array.isArray(json.groups) ? json.groups.map(Group.decode) : [], typeof json.attributes === 'object' ? json.attributes : {}, json.tozny_id);
     }
 }
 module.exports = DetailedIdentity;

--- a/src/__tests__/realm.test.js
+++ b/src/__tests__/realm.test.js
@@ -246,6 +246,8 @@ describe('Account Client', () => {
         realmName,
         sovereignName.toLowerCase()
       )
+      expect(idDetails.id).toBeTruthy()
+      expect(idDetails.toznyId).toBeTruthy()
       expect(idDetails).toBeInstanceOf(DetailedIdentity)
       expect(idDetails.username).toBe(sovereignName.toLowerCase())
       expect(

--- a/src/types/detailedIdentity.js
+++ b/src/types/detailedIdentity.js
@@ -15,9 +15,11 @@ class DetailedIdentity {
     federated,
     roles,
     groups,
-    attributes
+    attributes,
+    tozny_id
   ) {
     this.id = id
+    this.toznyId = tozny_id
     this.username = username
     this.email = email
     this.firstName = firstName
@@ -36,6 +38,7 @@ class DetailedIdentity {
    * <code>
    * identity = DetailedIdentity::decode({
    *   id: '00000000-0000-0000-0000-000000000000',
+   *   tozny_id: '00000000-0000-0000-0000-000000000000',
    *   name: 'jsmith',
    *   email: 'jsmith@example.com'
    *   first_name: 'John',
@@ -95,7 +98,8 @@ class DetailedIdentity {
       json.federated,
       GroupRoleMapping.decode(json.roles),
       Array.isArray(json.groups) ? json.groups.map(Group.decode) : [],
-      typeof json.attributes === 'object' ? json.attributes : {}
+      typeof json.attributes === 'object' ? json.attributes : {},
+      json.tozny_id
     )
   }
 }


### PR DESCRIPTION
~tests will fail until identity service change is merged and deployed~
added failing test that should pass now that identity service has been deployed.

* adds `toznyId` to `DetailedIdentity` object
* the `toznyId` is used by various other api calls, like `deleteIdentity` & `leaveGroups`