### PR TITLE
[WR-208] add upsert & list PAM policies

### DIFF
--- a/dist/account.js
+++ b/dist/account.js
@@ -41,7 +41,7 @@ class Account {
      */
     constructor(sdk, apiUrl = constants_1.DEFAULT_API_URL) {
         this.api = new api_1.default(apiUrl);
-        this._sdk = (0, utils_1.validatePlatformSDK)(sdk);
+        this._sdk = utils_1.validatePlatformSDK(sdk);
     }
     /**
      * gets the current crypto implementation provided by the Tozny client SDK.
@@ -147,7 +147,7 @@ class Account {
      */
     register(name, email, password) {
         return __awaiter(this, void 0, void 0, function* () {
-            (0, utils_1.validateEmail)(email);
+            utils_1.validateEmail(email);
             const encSalt = yield this.crypto.randomBytes(16);
             const authSalt = yield this.crypto.randomBytes(16);
             const paperEncSalt = yield this.crypto.randomBytes(16);

--- a/dist/api/defaultRealmGroups.js
+++ b/dist/api/defaultRealmGroups.js
@@ -14,7 +14,7 @@ const utils_1 = require("../utils");
 function listDefaultRealmGroups({ realmName }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/default-groups`, { method: 'GET' });
-        const { groups } = (yield (0, utils_1.validateRequestAsJSON)(response));
+        const { groups } = (yield utils_1.validateRequestAsJSON(response));
         return groups;
     });
 }
@@ -25,7 +25,7 @@ function replaceDefaultRealmGroups({ realmName, groups }, { apiUrl, queenClient 
             method: 'PUT',
             body: JSON.stringify(groups),
         });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }
@@ -36,7 +36,7 @@ function addDefaultRealmGroups({ realmName, groups }, { apiUrl, queenClient }) {
             method: 'PATCH',
             body: JSON.stringify(groups),
         });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }
@@ -47,7 +47,7 @@ function removeDefaultRealmGroups({ realmName, groups }, { apiUrl, queenClient }
             method: 'DELETE',
             body: JSON.stringify(groups),
         });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }

--- a/dist/api/groupMembership.js
+++ b/dist/api/groupMembership.js
@@ -16,7 +16,7 @@ function groupMembership({ realmName, identityId }, { apiUrl, queenClient }) {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/identity/${identityId}/groups`, {
             method: 'GET',
         });
-        const { groups } = (yield (0, utils_1.validateRequestAsJSON)(response));
+        const { groups } = (yield utils_1.validateRequestAsJSON(response));
         return groups;
     });
 }
@@ -27,7 +27,7 @@ function updateGroupMembership({ realmName, identityId, groups }, { apiUrl, quee
             method: 'PUT',
             body: JSON.stringify(groups),
         });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }
@@ -38,7 +38,7 @@ function joinGroups({ realmName, identityId, groups }, { apiUrl, queenClient }) 
             method: 'PATCH',
             body: JSON.stringify(groups),
         });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }
@@ -49,7 +49,7 @@ function leaveGroups({ realmName, identityId, groups }, { apiUrl, queenClient })
             method: 'DELETE',
             body: JSON.stringify(groups),
         });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }

--- a/dist/api/groupRoleMappings.js
+++ b/dist/api/groupRoleMappings.js
@@ -15,7 +15,7 @@ const roleMappingForGroupUri = (apiUrl, realmName, groupId) => `${apiUrl}/v1/ide
 function listGroupRoleMappings({ groupId, realmName }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(roleMappingForGroupUri(apiUrl, realmName, groupId), { method: 'GET' });
-        return (0, utils_1.validateRequestAsJSON)(response);
+        return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.listGroupRoleMappings = listGroupRoleMappings;
@@ -25,7 +25,7 @@ function addGroupRoleMappings({ realmName, groupId, groupRoleMapping }, { apiUrl
             method: 'POST',
             body: JSON.stringify(groupRoleMapping),
         });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }
@@ -36,7 +36,7 @@ function removeGroupRoleMappings({ realmName, groupId, groupRoleMapping }, { api
             method: 'DELETE',
             body: JSON.stringify(groupRoleMapping),
         });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }

--- a/dist/api/identity.js
+++ b/dist/api/identity.js
@@ -9,28 +9,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.deleteIdentity = exports.registerIdentity = exports.realmInfo = void 0;
+exports.deleteIdentity = exports.registerIdentity = void 0;
 const utils_1 = require("../utils");
-function realmInfo({ realm_name, apiUrl, }) {
+const realmSettings_1 = require("./realmSettings");
+function registerIdentity({ realmName, realmRegistrationToken, identity }, ctx) {
     return __awaiter(this, void 0, void 0, function* () {
-        let lowerCasedRealmName = realm_name.toLowerCase();
-        const response = yield fetch(`${apiUrl}/v1/identity/info/realm/${lowerCasedRealmName}`, {
-            method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-        });
-        const realmInfo = (yield (0, utils_1.validateRequestAsJSON)(response));
-        return realmInfo;
-    });
-}
-exports.realmInfo = realmInfo;
-function registerIdentity({ realm_name, realm_registration_token, identity }, { apiUrl }) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const info = yield realmInfo({ realm_name, apiUrl });
-        let username = identity.name.toLowerCase();
+        const info = yield realmSettings_1.getRealmInfo({ realmName }, ctx);
+        const username = identity.name.toLowerCase();
         const payload = {
-            realm_registration_token: realm_registration_token,
+            realm_registration_token: realmRegistrationToken,
             realm_name: info.domain,
             identity: {
                 realm_name: info.domain,
@@ -42,14 +29,14 @@ function registerIdentity({ realm_name, realm_registration_token, identity }, { 
                 email: identity.email,
             },
         };
-        const request = yield fetch(apiUrl + '/v1/identity/register', {
+        const request = yield fetch(ctx.apiUrl + '/v1/identity/register', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify(payload),
         });
-        const identityResponse = (yield (0, utils_1.validateRequestAsJSON)(request));
+        const identityResponse = (yield utils_1.validateRequestAsJSON(request));
         return identityResponse;
     });
 }
@@ -62,7 +49,7 @@ function deleteIdentity({ realmName, identityId }, { apiUrl, queenClient }) {
                 'Content-Type': 'application/json',
             },
         });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }

--- a/dist/api/index.js
+++ b/dist/api/index.js
@@ -17,16 +17,18 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * Account level API request definitions.
  */
 const isomorphic_fetch_1 = __importDefault(require("isomorphic-fetch"));
-const realmRoles_1 = require("./realmRoles");
-const token_1 = __importDefault(require("./token"));
 const utils_1 = require("../utils");
 const constants_1 = require("../utils/constants");
-const realmGroups_1 = require("./realmGroups");
-const groupRoleMappings_1 = require("./groupRoleMappings");
-const groupMembership_1 = require("./groupMembership");
-const realmApplicationRoles_1 = require("./realmApplicationRoles");
 const defaultRealmGroups_1 = require("./defaultRealmGroups");
+const groupMembership_1 = require("./groupMembership");
+const groupRoleMappings_1 = require("./groupRoleMappings");
 const identity_1 = require("./identity");
+const pam_1 = require("./pam");
+const realmApplicationRoles_1 = require("./realmApplicationRoles");
+const realmGroups_1 = require("./realmGroups");
+const realmRoles_1 = require("./realmRoles");
+const realmSettings_1 = require("./realmSettings");
+const token_1 = __importDefault(require("./token"));
 /**
  * API abstracts over the actual API calls made for various account-level operations.
  */
@@ -119,14 +121,14 @@ class API {
             const body = JSON.stringify({
                 email: username,
             });
-            const request = yield (0, isomorphic_fetch_1.default)(this.apiUrl + '/v1/account/challenge', {
+            const request = yield isomorphic_fetch_1.default(this.apiUrl + '/v1/account/challenge', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
                 body,
             });
-            return (0, utils_1.validateRequestAsJSON)(request);
+            return utils_1.validateRequestAsJSON(request);
         });
     }
     /**
@@ -140,7 +142,7 @@ class API {
      */
     completeChallenge(username, challenge, response, keyType) {
         return __awaiter(this, void 0, void 0, function* () {
-            const request = yield (0, isomorphic_fetch_1.default)(this.apiUrl + '/v1/account/auth', {
+            const request = yield isomorphic_fetch_1.default(this.apiUrl + '/v1/account/auth', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -152,7 +154,7 @@ class API {
                     keyid: keyType,
                 }),
             });
-            return (0, utils_1.validateRequestAsJSON)(request);
+            return utils_1.validateRequestAsJSON(request);
         });
     }
     /**
@@ -165,11 +167,11 @@ class API {
             const headers = yield this.withToken({
                 'Content-Type': 'application/json',
             });
-            const request = yield (0, isomorphic_fetch_1.default)(this.apiUrl + '/v1/account/profile/meta', {
+            const request = yield isomorphic_fetch_1.default(this.apiUrl + '/v1/account/profile/meta', {
                 method: 'GET',
                 headers,
             });
-            return (0, utils_1.validateRequestAsJSON)(request);
+            return utils_1.validateRequestAsJSON(request);
         });
     }
     /**
@@ -182,12 +184,12 @@ class API {
             const headers = yield this.withToken({
                 'Content-Type': 'application/json',
             });
-            const request = yield (0, isomorphic_fetch_1.default)(this.apiUrl + '/v1/account/profile/meta', {
+            const request = yield isomorphic_fetch_1.default(this.apiUrl + '/v1/account/profile/meta', {
                 method: 'PUT',
                 headers,
                 body: JSON.stringify(metaMap),
             });
-            return (0, utils_1.checkStatus)(request);
+            return utils_1.checkStatus(request);
         });
     }
     /**
@@ -201,14 +203,14 @@ class API {
                 profile: profile,
                 account: account,
             });
-            const request = yield (0, isomorphic_fetch_1.default)(this.apiUrl + '/v1/account/profile', {
+            const request = yield isomorphic_fetch_1.default(this.apiUrl + '/v1/account/profile', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
                 body,
             });
-            return (0, utils_1.validateRequestAsJSON)(request);
+            return utils_1.validateRequestAsJSON(request);
         });
     }
     /**
@@ -233,7 +235,7 @@ class API {
                 },
                 body,
             });
-            return (0, utils_1.validateRequestAsJSON)(request);
+            return utils_1.validateRequestAsJSON(request);
         });
     }
     /** requests email verification for a tozny account
@@ -248,10 +250,10 @@ class API {
      */
     verifyEmail(id, otp) {
         return __awaiter(this, void 0, void 0, function* () {
-            const request = yield (0, isomorphic_fetch_1.default)(this.apiUrl + `/v1/account/profile/verified?id=${id}&otp=${otp}`, {
+            const request = yield isomorphic_fetch_1.default(this.apiUrl + `/v1/account/profile/verified?id=${id}&otp=${otp}`, {
                 method: 'GET',
             });
-            return (0, utils_1.checkStatus)(request);
+            return utils_1.checkStatus(request);
         });
     }
     /** requests email verification for Tozny account be resent
@@ -264,7 +266,7 @@ class API {
             const headers = yield this.withToken({
                 'Content-Type': 'application/json',
             });
-            const request = yield (0, isomorphic_fetch_1.default)(this.apiUrl + '/v1/account/profile', {
+            const request = yield isomorphic_fetch_1.default(this.apiUrl + '/v1/account/profile', {
                 method: 'PATCH',
                 headers,
                 body: JSON.stringify({
@@ -273,27 +275,27 @@ class API {
                     },
                 }),
             });
-            return (0, utils_1.checkStatus)(request);
+            return utils_1.checkStatus(request);
         });
     }
     initiateRecoverAccount(email) {
         return __awaiter(this, void 0, void 0, function* () {
-            const response = yield (0, isomorphic_fetch_1.default)(this.apiUrl + '/v1/account/challenge/email/reset', {
+            const response = yield isomorphic_fetch_1.default(this.apiUrl + '/v1/account/challenge/email/reset', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     email: email,
                 }),
             });
-            return (0, utils_1.checkStatus)(response);
+            return utils_1.checkStatus(response);
         });
     }
     verifyRecoverAccountChallenge(id, otp) {
         return __awaiter(this, void 0, void 0, function* () {
-            const response = yield (0, isomorphic_fetch_1.default)(this.apiUrl + `/v1/account/profile/authenticate?id=${id}&otp=${otp}`, {
+            const response = yield isomorphic_fetch_1.default(this.apiUrl + `/v1/account/profile/authenticate?id=${id}&otp=${otp}`, {
                 method: 'GET',
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     rollQueen(client) {
@@ -301,12 +303,12 @@ class API {
             const headers = yield this.withToken({
                 'Content-Type': 'application/json',
             });
-            const response = yield (0, isomorphic_fetch_1.default)(this.apiUrl + `/v1/account/e3db/clients/queen`, {
+            const response = yield isomorphic_fetch_1.default(this.apiUrl + `/v1/account/e3db/clients/queen`, {
                 method: 'POST',
                 headers,
                 body: JSON.stringify({ client }),
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     getBillingStatus(queenClient) {
@@ -314,7 +316,7 @@ class API {
             const response = yield queenClient.authenticator.tokenFetch(this.apiUrl + '/v1/billing/subscription/status', {
                 method: 'GET',
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     addBillingCoupon(queenClient, couponCode) {
@@ -324,7 +326,7 @@ class API {
                 'Content-Type': 'application/json',
                 body: JSON.stringify({ coupon_code: couponCode }),
             });
-            return (0, utils_1.checkStatus)(response);
+            return utils_1.checkStatus(response);
         });
     }
     updateAccountBilling(account) {
@@ -332,14 +334,14 @@ class API {
             const headers = yield this.withToken({
                 'Content-Type': 'application/json',
             });
-            const response = yield (0, isomorphic_fetch_1.default)(this.apiUrl + '/v1/account/profile', {
+            const response = yield isomorphic_fetch_1.default(this.apiUrl + '/v1/account/profile', {
                 method: 'PATCH',
                 headers: headers,
                 body: JSON.stringify({
                     account: account,
                 }),
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     subscribe(queenClient) {
@@ -347,7 +349,7 @@ class API {
             const response = yield queenClient.authenticator.tokenFetch(this.apiUrl + '/v1/billing/resubscribe', {
                 method: 'GET',
             });
-            return (0, utils_1.checkStatus)(response);
+            return utils_1.checkStatus(response);
         });
     }
     unsubscribe(queenClient) {
@@ -355,7 +357,7 @@ class API {
             const response = yield queenClient.authenticator.tokenFetch(this.apiUrl + '/v1/billing/unsubscribe', {
                 method: 'GET',
             });
-            return (0, utils_1.checkStatus)(response);
+            return utils_1.checkStatus(response);
         });
     }
     listClients(queenClient, nextToken, perPage = 50) {
@@ -363,7 +365,7 @@ class API {
             const response = yield queenClient.authenticator.tokenFetch(`${this.apiUrl}/v1/client/admin?next=${nextToken}&limit=${perPage}`, {
                 method: 'GET',
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     getClient(queenClient, clientId) {
@@ -371,7 +373,7 @@ class API {
             const response = yield queenClient.authenticator.tokenFetch(this.apiUrl + `/v1/client/admin/${clientId}`, {
                 method: 'GET',
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     setClientEnabled(queenClient, clientId, enabled) {
@@ -380,7 +382,7 @@ class API {
                 method: 'PATCH',
                 body: JSON.stringify({ enabled }),
             });
-            return (0, utils_1.checkStatus)(request);
+            return utils_1.checkStatus(request);
         });
     }
     updateProfile(profile) {
@@ -388,12 +390,12 @@ class API {
             const headers = yield this.withToken({
                 'Content-Type': 'application/json',
             });
-            const request = yield (0, isomorphic_fetch_1.default)(this.apiUrl + '/v1/account/profile', {
+            const request = yield isomorphic_fetch_1.default(this.apiUrl + '/v1/account/profile', {
                 method: 'PATCH',
                 headers,
                 body: JSON.stringify({ profile: profile }),
             });
-            return (0, utils_1.validateRequestAsJSON)(request);
+            return utils_1.validateRequestAsJSON(request);
         });
     }
     /**
@@ -406,11 +408,11 @@ class API {
             const headers = yield this.withToken({
                 'Content-Type': 'application/json',
             });
-            const response = yield (0, isomorphic_fetch_1.default)(this.apiUrl + `/v1/account/tokens`, {
+            const response = yield isomorphic_fetch_1.default(this.apiUrl + `/v1/account/tokens`, {
                 method: 'GET',
                 headers,
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     /**
@@ -433,12 +435,12 @@ class API {
             const headers = yield this.withToken({
                 'Content-Type': 'application/json',
             });
-            const response = yield (0, isomorphic_fetch_1.default)(this.apiUrl + `/v1/account/tokens`, {
+            const response = yield isomorphic_fetch_1.default(this.apiUrl + `/v1/account/tokens`, {
                 method: 'POST',
                 headers,
                 body,
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     /**
@@ -453,11 +455,11 @@ class API {
             const headers = yield this.withToken({
                 'Content-Type': 'application/json',
             });
-            const response = yield (0, isomorphic_fetch_1.default)(`${this.apiUrl}/v1/account/tokens/${token}`, {
+            const response = yield isomorphic_fetch_1.default(`${this.apiUrl}/v1/account/tokens/${token}`, {
                 method: 'DELETE',
                 headers,
             });
-            yield (0, utils_1.checkStatus)(response);
+            yield utils_1.checkStatus(response);
             return true;
         });
     }
@@ -471,7 +473,7 @@ class API {
             const response = yield queenClient.authenticator.tokenFetch(this.apiUrl + `/v1/hook`, {
                 method: 'GET',
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     /**
@@ -498,7 +500,7 @@ class API {
                 method: 'POST',
                 body,
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     /**
@@ -513,7 +515,7 @@ class API {
             const response = yield queenClient.authenticator.tokenFetch(this.apiUrl + `/v1/hook/${webhookId}`, {
                 method: 'DELETE',
             });
-            yield (0, utils_1.checkStatus)(response);
+            yield utils_1.checkStatus(response);
             return true;
         });
     }
@@ -534,7 +536,7 @@ class API {
                 method: 'POST',
                 body: body,
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     /**
@@ -557,7 +559,7 @@ class API {
                 method: 'POST',
                 body: JSON.stringify(createRealmRequest),
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     /**
@@ -572,7 +574,7 @@ class API {
             const response = yield queenClient.authenticator.tsv1Fetch(this.apiUrl + '/v1/identity/realm', {
                 method: 'GET',
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     /**
@@ -588,7 +590,15 @@ class API {
             const response = yield queenClient.authenticator.tsv1Fetch(this.apiUrl + `/v1/identity/realm/${realmName}`, {
                 method: 'DELETE',
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
+        });
+    }
+    /** Updates the settings for the given realm. */
+    updateRealmSettings(queenClient, realmName, settings) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield realmSettings_1.updateRealmSettings({ realmName, settings }, { apiUrl: this.apiUrl, queenClient });
+            // no error means it worked
+            return settings;
         });
     }
     getAggregations(queenClient, accountId, startTime, endTime) {
@@ -604,7 +614,7 @@ class API {
                 method: 'POST',
                 body: body,
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     /**
@@ -612,7 +622,7 @@ class API {
      */
     createRealmGroup(queenClient, realmName, group) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmGroups_1.createRealmGroup)({ realmName, group }, { apiUrl: this.apiUrl, queenClient });
+            return realmGroups_1.createRealmGroup({ realmName, group }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -620,7 +630,7 @@ class API {
      */
     updateRealmGroup(queenClient, realmName, groupId, group) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmGroups_1.updateRealmGroup)({ realmName, groupId, group }, { apiUrl: this.apiUrl, queenClient });
+            return realmGroups_1.updateRealmGroup({ realmName, groupId, group }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -628,7 +638,7 @@ class API {
      */
     deleteRealmGroup(queenClient, realmName, groupId) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield (0, realmGroups_1.deleteRealmGroup)({ realmName, groupId }, { apiUrl: this.apiUrl, queenClient });
+            yield realmGroups_1.deleteRealmGroup({ realmName, groupId }, { apiUrl: this.apiUrl, queenClient });
             return true;
         });
     }
@@ -637,7 +647,7 @@ class API {
      */
     describeRealmGroup(queenClient, realmName, groupId) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmGroups_1.describeRealmGroup)({ realmName, groupId }, { apiUrl: this.apiUrl, queenClient });
+            return realmGroups_1.describeRealmGroup({ realmName, groupId }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -645,7 +655,7 @@ class API {
      */
     listRealmGroups(queenClient, realmName) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmGroups_1.listRealmGroups)({ realmName }, { apiUrl: this.apiUrl, queenClient });
+            return realmGroups_1.listRealmGroups({ realmName }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -653,7 +663,7 @@ class API {
      */
     createRealmRole(queenClient, realmName, role) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmRoles_1.createRealmRole)({ realmName, role }, { apiUrl: this.apiUrl, queenClient });
+            return realmRoles_1.createRealmRole({ realmName, role }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -661,7 +671,7 @@ class API {
      */
     updateRealmRole(queenClient, realmName, role) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmRoles_1.updateRealmRole)({ realmName, role }, { apiUrl: this.apiUrl, queenClient });
+            return realmRoles_1.updateRealmRole({ realmName, role }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -669,7 +679,7 @@ class API {
      */
     deleteRealmRole(queenClient, realmName, roleId) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield (0, realmRoles_1.deleteRealmRole)({ realmName, roleId }, { apiUrl: this.apiUrl, queenClient });
+            yield realmRoles_1.deleteRealmRole({ realmName, roleId }, { apiUrl: this.apiUrl, queenClient });
             return true;
         });
     }
@@ -678,7 +688,7 @@ class API {
      */
     describeRealmRole(queenClient, realmName, roleId) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmRoles_1.describeRealmRole)({ realmName, roleId }, { apiUrl: this.apiUrl, queenClient });
+            return realmRoles_1.describeRealmRole({ realmName, roleId }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -686,7 +696,7 @@ class API {
      */
     listRealmRoles(queenClient, realmName) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmRoles_1.listRealmRoles)({ realmName }, { apiUrl: this.apiUrl, queenClient });
+            return realmRoles_1.listRealmRoles({ realmName }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -694,7 +704,7 @@ class API {
      */
     createRealmApplicationRole(queenClient, realmName, applicationId, role) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmApplicationRoles_1.createRealmApplicationRole)({ realmName, applicationId, role }, { apiUrl: this.apiUrl, queenClient });
+            return realmApplicationRoles_1.createRealmApplicationRole({ realmName, applicationId, role }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -702,7 +712,7 @@ class API {
      */
     updateRealmApplicationRole(queenClient, realmName, applicationId, originalRoleName, role) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmApplicationRoles_1.updateRealmApplicationRole)({ realmName, applicationId, originalRoleName, role }, { apiUrl: this.apiUrl, queenClient });
+            return realmApplicationRoles_1.updateRealmApplicationRole({ realmName, applicationId, originalRoleName, role }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -710,7 +720,7 @@ class API {
      */
     deleteRealmApplicationRole(queenClient, realmName, applicationId, roleName) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield (0, realmApplicationRoles_1.deleteRealmApplicationRole)({ realmName, applicationId, roleName }, { apiUrl: this.apiUrl, queenClient });
+            yield realmApplicationRoles_1.deleteRealmApplicationRole({ realmName, applicationId, roleName }, { apiUrl: this.apiUrl, queenClient });
             return true;
         });
     }
@@ -719,7 +729,7 @@ class API {
      */
     describeRealmApplicationRole(queenClient, realmName, applicationId, roleName) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmApplicationRoles_1.describeRealmApplicationRole)({ realmName, applicationId, roleName }, { apiUrl: this.apiUrl, queenClient });
+            return realmApplicationRoles_1.describeRealmApplicationRole({ realmName, applicationId, roleName }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -727,7 +737,7 @@ class API {
      */
     listRealmApplicationRoles(queenClient, realmName, applicationId) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, realmApplicationRoles_1.listRealmApplicationRoles)({ realmName, applicationId }, { apiUrl: this.apiUrl, queenClient });
+            return realmApplicationRoles_1.listRealmApplicationRoles({ realmName, applicationId }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -735,7 +745,7 @@ class API {
      */
     groupMembership(queenClient, realmName, identityId) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, groupMembership_1.groupMembership)({ realmName, identityId }, { apiUrl: this.apiUrl, queenClient });
+            return groupMembership_1.groupMembership({ realmName, identityId }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -743,7 +753,7 @@ class API {
      */
     updateGroupMembership(queenClient, realmName, identityId, groups) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, groupMembership_1.updateGroupMembership)({ realmName, identityId, groups }, { apiUrl: this.apiUrl, queenClient });
+            return groupMembership_1.updateGroupMembership({ realmName, identityId, groups }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -751,7 +761,7 @@ class API {
      */
     joinGroups(queenClient, realmName, identityId, groups) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, groupMembership_1.joinGroups)({ realmName, identityId, groups }, { apiUrl: this.apiUrl, queenClient });
+            return groupMembership_1.joinGroups({ realmName, identityId, groups }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -759,7 +769,7 @@ class API {
      */
     leaveGroups(queenClient, realmName, identityId, groups) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, groupMembership_1.leaveGroups)({ realmName, identityId, groups }, { apiUrl: this.apiUrl, queenClient });
+            return groupMembership_1.leaveGroups({ realmName, identityId, groups }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -768,7 +778,7 @@ class API {
      */
     listGroupRoleMappings(queenClient, realmName, groupId) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, groupRoleMappings_1.listGroupRoleMappings)({ groupId, realmName }, { apiUrl: this.apiUrl, queenClient });
+            return groupRoleMappings_1.listGroupRoleMappings({ groupId, realmName }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -776,7 +786,7 @@ class API {
      */
     addGroupRoleMappings(queenClient, realmName, groupId, groupRoleMapping) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield (0, groupRoleMappings_1.addGroupRoleMappings)({ realmName, groupId, groupRoleMapping }, { apiUrl: this.apiUrl, queenClient });
+            yield groupRoleMappings_1.addGroupRoleMappings({ realmName, groupId, groupRoleMapping }, { apiUrl: this.apiUrl, queenClient });
             return true;
         });
     }
@@ -785,7 +795,7 @@ class API {
      */
     removeGroupRoleMappings(queenClient, realmName, groupId, groupRoleMapping) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield (0, groupRoleMappings_1.removeGroupRoleMappings)({ realmName, groupId, groupRoleMapping }, { apiUrl: this.apiUrl, queenClient });
+            yield groupRoleMappings_1.removeGroupRoleMappings({ realmName, groupId, groupRoleMapping }, { apiUrl: this.apiUrl, queenClient });
             return true;
         });
     }
@@ -794,7 +804,7 @@ class API {
      */
     listDefaultRealmGroups(queenClient, realmName) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, defaultRealmGroups_1.listDefaultRealmGroups)({ realmName }, { apiUrl: this.apiUrl, queenClient });
+            return defaultRealmGroups_1.listDefaultRealmGroups({ realmName }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -802,7 +812,7 @@ class API {
      */
     replaceDefaultRealmGroups(queenClient, realmName, groups) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, defaultRealmGroups_1.replaceDefaultRealmGroups)({ realmName, groups }, { apiUrl: this.apiUrl, queenClient });
+            return defaultRealmGroups_1.replaceDefaultRealmGroups({ realmName, groups }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -810,7 +820,7 @@ class API {
      */
     addDefaultRealmGroups(queenClient, realmName, groups) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, defaultRealmGroups_1.addDefaultRealmGroups)({ realmName, groups }, { apiUrl: this.apiUrl, queenClient });
+            return defaultRealmGroups_1.addDefaultRealmGroups({ realmName, groups }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -818,15 +828,15 @@ class API {
      */
     removeDefaultRealmGroups(queenClient, realmName, groups) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, defaultRealmGroups_1.removeDefaultRealmGroups)({ realmName, groups }, { apiUrl: this.apiUrl, queenClient });
+            return defaultRealmGroups_1.removeDefaultRealmGroups({ realmName, groups }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
-     *
+     * Registers a new identity with the realm
      */
-    registerIdentity(realm_name, realm_registration_token, identity) {
+    registerIdentity(realmName, realmRegistrationToken, identity) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, identity_1.registerIdentity)({ realm_name, realm_registration_token, identity }, { apiUrl: this.apiUrl });
+            return identity_1.registerIdentity({ realmName, realmRegistrationToken, identity }, { apiUrl: this.apiUrl });
         });
     }
     /**
@@ -834,7 +844,7 @@ class API {
      */
     deleteIdentity(queenClient, realmName, identityId) {
         return __awaiter(this, void 0, void 0, function* () {
-            return (0, identity_1.deleteIdentity)({ realmName, identityId }, { apiUrl: this.apiUrl, queenClient });
+            return identity_1.deleteIdentity({ realmName, identityId }, { apiUrl: this.apiUrl, queenClient });
         });
     }
     /**
@@ -844,8 +854,8 @@ class API {
      */
     getHostedBrokerInfo() {
         return __awaiter(this, void 0, void 0, function* () {
-            const response = yield (0, isomorphic_fetch_1.default)(`${this.apiUrl}/v1/identity/broker/info`);
-            return (0, utils_1.validateRequestAsJSON)(response);
+            const response = yield isomorphic_fetch_1.default(`${this.apiUrl}/v1/identity/broker/info`);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     /**
@@ -866,7 +876,7 @@ class API {
                 method: 'POST',
                 body: JSON.stringify(registerRealmBrokerRequest),
             });
-            const requestResponse = (yield (0, utils_1.validateRequestAsJSON)(response));
+            const requestResponse = (yield utils_1.validateRequestAsJSON(response));
             return requestResponse;
         });
     }
@@ -893,7 +903,7 @@ class API {
             const response = yield queenClient.authenticator.tsv1Fetch(fullUrl, {
                 method: 'GET',
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
         });
     }
     /**
@@ -909,7 +919,17 @@ class API {
             const response = yield queenClient.authenticator.tsv1Fetch(`${this.apiUrl}/v1/identity/realm/${realmName}/identity/${encUsername}`, {
                 method: 'GET',
             });
-            return (0, utils_1.validateRequestAsJSON)(response);
+            return utils_1.validateRequestAsJSON(response);
+        });
+    }
+    listAccessPoliciesForGroups(queenClient, realmName, groupIds) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return pam_1.listAccessPoliciesForGroups({ realmName, groupIds }, { apiUrl: this.apiUrl, queenClient });
+        });
+    }
+    upsertAccessPoliciesForGroup(queenClient, realmName, groupId, accessPolicies) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return pam_1.upsertAccessPoliciesForGroup({ realmName, groupId, accessPolicies }, { apiUrl: this.apiUrl, queenClient });
         });
     }
 }

--- a/dist/api/pam.js
+++ b/dist/api/pam.js
@@ -9,32 +9,29 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.UpsertAccessPolicies = exports.listAccessPolicies = void 0;
-const utils_1 = require("../utils");
+exports.upsertAccessPoliciesForGroup = exports.listAccessPoliciesForGroups = void 0;
 const role_1 = require("../types/role");
-function listAccessPolicies({ realmName, groupIds }, { apiUrl, queenClient }) {
+const utils_1 = require("../utils");
+function listAccessPoliciesForGroups({ realmName, groupIds }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
-        var query = new URLSearchParams();
+        // build query string
+        const query = new URLSearchParams();
         query.set('realm_name', encodeURIComponent(realmName));
         groupIds.forEach(groupId => query.append('group_ids', encodeURIComponent(groupId)));
-        const request = yield queenClient.authenticator.tsv1Fetch(apiUrl + '/v1/identity/pam/polcies?${query.toString()}', {
-            method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-        });
-        const accessPolicyResponse = (yield utils_1.validateRequestAsJSON(request));
-        return accessPolicyResponse;
+        // send request
+        const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/pam/policies?${query.toString()}`, { method: 'GET' });
+        const data = yield utils_1.validateRequestAsJSON(response);
+        return data;
     });
 }
-exports.listAccessPolicies = listAccessPolicies;
-function UpsertAccessPolicies({ realmName, groupId, accessPolicies }, { apiUrl, queenClient }) {
+exports.listAccessPoliciesForGroups = listAccessPoliciesForGroups;
+function upsertAccessPoliciesForGroup({ realmName, groupId, accessPolicies }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const payload = {
             realm_name: realmName,
             group: {
                 id: groupId,
-                accessPolicies: accessPolicies.map(ap => ({
+                access_policies: accessPolicies.map(ap => ({
                     id: ap.id,
                     required_approvals: ap.requiredApprovals,
                     max_access_duration_seconds: ap.maxAccessDurationSeconds,
@@ -44,13 +41,11 @@ function UpsertAccessPolicies({ realmName, groupId, accessPolicies }, { apiUrl, 
         };
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/pam/policies`, {
             method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json',
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
-        utils_1.checkStatus(response);
-        return;
+        const data = yield utils_1.validateRequestAsJSON(response);
+        return data.group;
     });
 }
-exports.UpsertAccessPolicies = UpsertAccessPolicies;
+exports.upsertAccessPoliciesForGroup = upsertAccessPoliciesForGroup;

--- a/dist/api/pam.js
+++ b/dist/api/pam.js
@@ -1,0 +1,56 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.UpsertAccessPolicies = exports.listAccessPolicies = void 0;
+const utils_1 = require("../utils");
+const role_1 = require("../types/role");
+function listAccessPolicies({ realmName, groupIds }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var query = new URLSearchParams();
+        query.set('realm_name', encodeURIComponent(realmName));
+        groupIds.forEach(groupId => query.append('group_ids', encodeURIComponent(groupId)));
+        const request = yield queenClient.authenticator.tsv1Fetch(apiUrl + '/v1/identity/pam/polcies?${query.toString()}', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        const accessPolicyResponse = (yield utils_1.validateRequestAsJSON(request));
+        return accessPolicyResponse;
+    });
+}
+exports.listAccessPolicies = listAccessPolicies;
+function UpsertAccessPolicies({ realmName, groupId, accessPolicies }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const payload = {
+            realm_name: realmName,
+            group: {
+                id: groupId,
+                accessPolicies: accessPolicies.map(ap => ({
+                    id: ap.id,
+                    required_approvals: ap.requiredApprovals,
+                    max_access_duration_seconds: ap.maxAccessDurationSeconds,
+                    approval_roles: ap.approvalRoles.map(role_1.roleToAPI),
+                })),
+            },
+        };
+        const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/pam/policies`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+        });
+        utils_1.checkStatus(response);
+        return;
+    });
+}
+exports.UpsertAccessPolicies = UpsertAccessPolicies;

--- a/dist/api/realmApplicationRoles.js
+++ b/dist/api/realmApplicationRoles.js
@@ -18,7 +18,7 @@ function createRealmApplicationRole({ realmName, applicationId, role }, { apiUrl
             method: 'POST',
             body: JSON.stringify(role),
         });
-        return (0, utils_1.validateRequestAsJSON)(response);
+        return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.createRealmApplicationRole = createRealmApplicationRole;
@@ -30,7 +30,7 @@ function updateRealmApplicationRole({ realmName, applicationId, originalRoleName
             method: 'PUT',
             body: JSON.stringify(role),
         });
-        return (0, utils_1.validateRequestAsJSON)(response);
+        return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.updateRealmApplicationRole = updateRealmApplicationRole;
@@ -41,7 +41,7 @@ function deleteRealmApplicationRole({ realmName, applicationId, roleName }, { ap
         const response = yield queenClient.authenticator.tsv1Fetch(uri, {
             method: 'DELETE',
         });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }
@@ -53,14 +53,14 @@ function describeRealmApplicationRole({ realmName, applicationId, roleName }, { 
         const response = yield queenClient.authenticator.tsv1Fetch(uri, {
             method: 'GET',
         });
-        return (0, utils_1.validateRequestAsJSON)(response);
+        return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.describeRealmApplicationRole = describeRealmApplicationRole;
 function listRealmApplicationRoles({ realmName, applicationId }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(realmApplicationRoleUri(apiUrl, realmName, applicationId), { method: 'GET' });
-        const { application_roles: roles } = (yield (0, utils_1.validateRequestAsJSON)(response));
+        const { application_roles: roles } = (yield utils_1.validateRequestAsJSON(response));
         return roles;
     });
 }

--- a/dist/api/realmGroups.js
+++ b/dist/api/realmGroups.js
@@ -27,7 +27,7 @@ function createRealmGroup({ realmName, group }, { apiUrl, queenClient }) {
             method: 'POST',
             body: JSON.stringify(transformAttributesForApi(group)),
         });
-        return (0, utils_1.validateRequestAsJSON)(response);
+        return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.createRealmGroup = createRealmGroup;
@@ -37,14 +37,14 @@ function updateRealmGroup({ realmName, groupId, group }, { apiUrl, queenClient }
             method: 'PUT',
             body: JSON.stringify(transformAttributesForApi(group)),
         });
-        return (0, utils_1.validateRequestAsJSON)(response);
+        return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.updateRealmGroup = updateRealmGroup;
 function deleteRealmGroup({ realmName, groupId }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}`, { method: 'DELETE' });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }
@@ -52,14 +52,14 @@ exports.deleteRealmGroup = deleteRealmGroup;
 function describeRealmGroup({ realmName, groupId }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group/${groupId}`, { method: 'GET' });
-        return (0, utils_1.validateRequestAsJSON)(response);
+        return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.describeRealmGroup = describeRealmGroup;
 function listRealmGroups({ realmName }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/group`, { method: 'GET' });
-        const { groups } = (yield (0, utils_1.validateRequestAsJSON)(response));
+        const { groups } = (yield utils_1.validateRequestAsJSON(response));
         return groups;
     });
 }

--- a/dist/api/realmRoles.js
+++ b/dist/api/realmRoles.js
@@ -17,7 +17,7 @@ function createRealmRole({ realmName, role }, { apiUrl, queenClient }) {
             method: 'POST',
             body: JSON.stringify(role),
         });
-        return (0, utils_1.validateRequestAsJSON)(response);
+        return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.createRealmRole = createRealmRole;
@@ -27,14 +27,14 @@ function updateRealmRole({ realmName, role }, { apiUrl, queenClient }) {
             method: 'PUT',
             body: JSON.stringify(role),
         });
-        return (0, utils_1.validateRequestAsJSON)(response);
+        return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.updateRealmRole = updateRealmRole;
 function deleteRealmRole({ realmName, roleId }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/role/${roleId}`, { method: 'DELETE' });
-        (0, utils_1.checkStatus)(response);
+        utils_1.checkStatus(response);
         return;
     });
 }
@@ -42,14 +42,14 @@ exports.deleteRealmRole = deleteRealmRole;
 function describeRealmRole({ realmName, roleId }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/role/${roleId}`, { method: 'GET' });
-        return (0, utils_1.validateRequestAsJSON)(response);
+        return utils_1.validateRequestAsJSON(response);
     });
 }
 exports.describeRealmRole = describeRealmRole;
 function listRealmRoles({ realmName }, { apiUrl, queenClient }) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/realm/${realmName}/role`, { method: 'GET' });
-        const { roles } = (yield (0, utils_1.validateRequestAsJSON)(response));
+        const { roles } = (yield utils_1.validateRequestAsJSON(response));
         return roles;
     });
 }

--- a/dist/api/realmSettings.js
+++ b/dist/api/realmSettings.js
@@ -1,0 +1,44 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.updateRealmSettings = exports.getRealmInfo = void 0;
+const utils_1 = require("../utils");
+/** not publicly exposed. used primarily internally for realmName -> domainName conversion */
+function getRealmInfo({ realmName }, { apiUrl }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield fetch(`${apiUrl}/v1/identity/info/realm/${realmName.toLowerCase()}`, { method: 'GET', headers: { 'Content-Type': 'application/json' } });
+        const realmInfo = (yield utils_1.validateRequestAsJSON(response));
+        return realmInfo;
+    });
+}
+exports.getRealmInfo = getRealmInfo;
+function updateRealmSettings({ realmName, settings: { secretsEnabled, mfaAvailable, emailLookupsEnabled, tozIDFederationEnabled, mpcEnabled, }, }, { apiUrl, queenClient }) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Get the Realm Domain
+        const info = yield getRealmInfo({ realmName }, { apiUrl, queenClient });
+        const payload = {
+            secrets_enabled: secretsEnabled,
+            mfa_available: mfaAvailable,
+            email_lookups_enabled: emailLookupsEnabled,
+            tozid_federation_enabled: tozIDFederationEnabled,
+            mpc_enabled: mpcEnabled,
+        };
+        // Update Realm Settings
+        const response = yield queenClient.authenticator.tsv1Fetch(`${apiUrl}/v1/identity/admin/realm/info/${info.domain}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        utils_1.checkStatus(response);
+        return;
+    });
+}
+exports.updateRealmSettings = updateRealmSettings;

--- a/dist/client.js
+++ b/dist/client.js
@@ -914,6 +914,31 @@ class Client {
             return this.api.resendVerificationEmail(email);
         });
     }
+    /**
+     * Lists the Current Access Policies for the Group Ids sent.
+     *
+     * @param {string} realmName Name of realm.
+     * @param {Array} groupIds  The IDs for the Tozny Groups
+     * @returns {Promise<ListAccessPolicyResponse>}
+     */
+    listAccessPolicies(realmName, groupIds) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.api.listAccessPolicies(this.queenClient, realmName, groupIds);
+        });
+    }
+    /**
+     *  Creating or Updating an Access Policy for a Group
+     *
+     * @param {string} realmName Name of realm.
+     * @param {string} groupId The ID of the Group in Tozny
+     * @param {AccessPolicy[]} accessPolicies Configuration for the new identity
+     * @returns {Promise<ListAccessPolicyResponse>}
+     */
+    upsertAccessPolicies(realmName, groupId, accessPolicies) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.api.UpsertAccessPolicies(this.queenClient, realmName, groupId, accessPolicies);
+        });
+    }
     serialize() {
         return {
             api: this.api.serialize(),

--- a/dist/client.js
+++ b/dist/client.js
@@ -22,6 +22,7 @@ const token_1 = __importDefault(require("./api/token"));
 const basicIdentity_1 = __importDefault(require("./types/basicIdentity"));
 const listIdentitiesResult_1 = __importDefault(require("./types/listIdentitiesResult"));
 const detailedIdentity_1 = __importDefault(require("./types/detailedIdentity"));
+const accessPolicy_1 = __importDefault(require("./types/accessPolicy"));
 /**
  * The client for Tozny's Account API.
  *
@@ -43,7 +44,7 @@ const detailedIdentity_1 = __importDefault(require("./types/detailedIdentity"));
 class Client {
     constructor(api, account, profile, queenClient) {
         this.api = api_1.default.validateInstance(api);
-        this._queenClient = (0, utils_1.validateStorageClient)(queenClient);
+        this._queenClient = utils_1.validateStorageClient(queenClient);
         this.account = account;
         this.profile = profile;
     }
@@ -304,6 +305,19 @@ class Client {
         });
     }
     /**
+     * Updates settings for the realm.
+     * Some of these features enabled by these settings are experimental and may be subject
+     * to change.
+     * @param {string} realmName Name of realm.
+     * @param {RealmSettings} settings Object containing settings to enable.
+     * @returns Updated realm settings.
+     */
+    updateRealmSettings(realmName, settings) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.api.updateRealmSettings(this.queenClient, realmName, settings);
+        });
+    }
+    /**
      * Creates a new group in the realm.
      *
      * @param {string} realmName Name of realm.
@@ -370,9 +384,11 @@ class Client {
     /**
      * Creates a new role for a realm.
      *
-     * @param {string} realmName  Name of realm.
-     * @param {object} role       Object with `name` and `description` of role.
-     * @returns {Promise<Role>}   The newly created role.
+     * @param {string} realmName Name of realm.
+     * @param {MinimumRoleData} role Object with `name` and `description` of role.
+     * @param {string} role.name Name of new role.
+     * @param {string} role.description Description of new role.
+     * @returns {Promise<Role>} The newly created role.
      */
     createRealmRole(realmName, role) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -384,8 +400,11 @@ class Client {
      * Update an existing role in the realm given a role id.
      *
      * @param {string} realmName Name of realm.
-     * @param {role} role        Updated attributes of the role.
-     * @returns {Promise<Role>}
+     * @param {MinimumRoleWithId} role Updated attributes of the role.
+     * @param {string} role.id Id of the role.
+     * @param {string} role.name Updated name of role.
+     * @param {string} role.description Updated description of the role.
+     * @returns {Promise<Role>} The updated role
      */
     updateRealmRole(realmName, role) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -918,12 +937,13 @@ class Client {
      * Lists the Current Access Policies for the Group Ids sent.
      *
      * @param {string} realmName Name of realm.
-     * @param {Array} groupIds  The IDs for the Tozny Groups
-     * @returns {Promise<ListAccessPolicyResponse>}
+     * @param {string[]} groupIds The IDs for the Tozny Groups
+     * @returns {Promise<ListAccessPoliciesResponse>}
      */
-    listAccessPolicies(realmName, groupIds) {
+    listAccessPoliciesForGroups(realmName, groupIds) {
         return __awaiter(this, void 0, void 0, function* () {
-            return this.api.listAccessPolicies(this.queenClient, realmName, groupIds);
+            const res = yield this.api.listAccessPoliciesForGroups(this.queenClient, realmName, groupIds);
+            return types_1.ListAccessPoliciesResponse.decode(res);
         });
     }
     /**
@@ -934,9 +954,13 @@ class Client {
      * @param {AccessPolicy[]} accessPolicies Configuration for the new identity
      * @returns {Promise<ListAccessPolicyResponse>}
      */
-    upsertAccessPolicies(realmName, groupId, accessPolicies) {
+    upsertAccessPoliciesForGroup(realmName, groupId, accessPolicies) {
         return __awaiter(this, void 0, void 0, function* () {
-            return this.api.UpsertAccessPolicies(this.queenClient, realmName, groupId, accessPolicies);
+            const res = yield this.api.upsertAccessPoliciesForGroup(this.queenClient, realmName, groupId, accessPolicies);
+            return {
+                id: res.id,
+                accessPolicies: res.access_policies.map(accessPolicy_1.default.decode),
+            };
         });
     }
     serialize() {

--- a/dist/types/accessPolicy.js
+++ b/dist/types/accessPolicy.js
@@ -1,0 +1,43 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const role_1 = __importDefault(require("./role"));
+class AccessPolicy {
+    constructor(id, approval_roles, required_approvals, max_access_duration_seconds) {
+        this.id = id;
+        this.approvalRoles = approval_roles;
+        this.maxAccessDurationSeconds = max_access_duration_seconds;
+        this.requiredApprovals = required_approvals;
+    }
+    /**
+     * Specify how an already unserialized JSON array should be marshaled into
+     * an object representation.
+     *
+     * <code>
+     * access_policy = AccessPolicy::decode({
+     *   id: '00000000-0000-0000-0000-000000000000',
+     *   approval_roles: Role::decode({
+     *   id: '00000000-0000-0000-0000-000000000000',
+     *   name: 'jsmith',
+     *   description: 'This role provides access to...'
+     *   composite: false',
+     *   client_role: trie,
+     *   container_id: '00000000-0000-0000-0000-000000000000',
+     * })
+     *   max_access_duration_seconds: '00',
+     *   required_approvals: '00',
+     * })
+     * <code>
+     *
+     * @param {object} json
+     *
+     * @return {<AccessPolicy>}
+     */
+    static decode(json) {
+        const realmRoles = json.approval_roles.map(role_1.default.decode);
+        return new AccessPolicy(json.id, realmRoles, json.required_approvals, json.max_access_duration_seconds);
+    }
+}
+exports.default = AccessPolicy;

--- a/dist/types/accessPolicy.js
+++ b/dist/types/accessPolicy.js
@@ -5,34 +5,17 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const role_1 = __importDefault(require("./role"));
 class AccessPolicy {
-    constructor(id, approval_roles, required_approvals, max_access_duration_seconds) {
+    constructor(id, approvalRoles, requiredApprovals, maxAccessDurationSeconds) {
         this.id = id;
-        this.approvalRoles = approval_roles;
-        this.maxAccessDurationSeconds = max_access_duration_seconds;
-        this.requiredApprovals = required_approvals;
+        this.approvalRoles = approvalRoles;
+        this.maxAccessDurationSeconds = maxAccessDurationSeconds;
+        this.requiredApprovals = requiredApprovals;
     }
     /**
      * Specify how an already unserialized JSON array should be marshaled into
      * an object representation.
      *
-     * <code>
-     * access_policy = AccessPolicy::decode({
-     *   id: '00000000-0000-0000-0000-000000000000',
-     *   approval_roles: Role::decode({
-     *   id: '00000000-0000-0000-0000-000000000000',
-     *   name: 'jsmith',
-     *   description: 'This role provides access to...'
-     *   composite: false',
-     *   client_role: trie,
-     *   container_id: '00000000-0000-0000-0000-000000000000',
-     * })
-     *   max_access_duration_seconds: '00',
-     *   required_approvals: '00',
-     * })
-     * <code>
-     *
-     * @param {object} json
-     *
+     * @param {ToznyAPIAccessPolicy} json
      * @return {<AccessPolicy>}
      */
     static decode(json) {

--- a/dist/types/index.js
+++ b/dist/types/index.js
@@ -2,6 +2,7 @@
 /**
  * Exposes the various defined types used in the Account SDK for easy consumption.
  */
+const AccessPolicy = require('./accessPolicy').default;
 const AccountBillingStatus = require('./accountBillingStatus');
 const BasicIdentity = require('./basicIdentity').default;
 const ClientInfo = require('./clientInfo');
@@ -10,6 +11,8 @@ const DetailedIdentity = require('./detailedIdentity');
 const Group = require('./group').default;
 const GroupRoleMapping = require('./groupRoleMapping').default;
 const Identity = require('./identity').default;
+const ListAccessPoliciesResponse = require('./listAccessPoliciesResponse')
+    .default;
 const ListIdentitiesResult = require('./listIdentitiesResult');
 const Realm = require('./realm');
 const Realms = require('./realms');
@@ -17,18 +20,20 @@ const RegistrationToken = require('./registrationToken');
 const Role = require('./role').default;
 const Sovereign = require('./sovereign');
 module.exports = {
+    AccessPolicy,
     AccountBillingStatus,
     BasicIdentity,
     ClientInfo,
     ClientInfoList,
     DetailedIdentity,
     Group,
+    GroupRoleMapping,
     Identity,
+    ListAccessPoliciesResponse,
     ListIdentitiesResult,
     Realm,
     Realms,
     RegistrationToken,
     Role,
-    GroupRoleMapping,
     Sovereign,
 };

--- a/dist/types/listAccessPoliciesResponse.js
+++ b/dist/types/listAccessPoliciesResponse.js
@@ -1,0 +1,25 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const accessPolicy_1 = __importDefault(require("./accessPolicy"));
+class ListAccessPoliciesResponse {
+    constructor(settings, groupAccessPolicies) {
+        this.settings = settings;
+        this.groupAccessPolicies = groupAccessPolicies;
+    }
+    static decode(api) {
+        const groups = api.groups.map(({ id, access_policies }) => ({
+            id,
+            accessPolicies: access_policies.map(accessPolicy_1.default.decode),
+        }));
+        const settings = {
+            defaultAccessDurationSeconds: api.settings.default_access_duration_seconds,
+            defaultRequiredApprovals: api.settings.default_required_approvals,
+            mpcEnabledForRealm: api.settings.mpc_enabled_for_realm,
+        };
+        return new ListAccessPoliciesResponse(settings, groups);
+    }
+}
+exports.default = ListAccessPoliciesResponse;

--- a/dist/types/realmSettings.js
+++ b/dist/types/realmSettings.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.decodeRealmSettings = void 0;
+/**
+ * decodeRealmSettings converts the API response type to the structure used by this package.
+ */
+function decodeRealmSettings(api) {
+    return {
+        emailLookupsEnabled: api.secrets_enabled,
+        mfaAvailable: api.mfa_available,
+        mpcEnabled: api.email_lookups_enabled,
+        secretsEnabled: api.tozid_federation_enabled,
+        tozIDFederationEnabled: api.mpc_enabled,
+    };
+}
+exports.decodeRealmSettings = decodeRealmSettings;

--- a/dist/types/role.js
+++ b/dist/types/role.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.roleToAPI = void 0;
 /**
  * A defined role which provides permissions in a realm.
  */
@@ -35,4 +36,15 @@ class Role {
         return new Role(json.id, json.name, json.description, json.composite, json.client_role, json.container_id);
     }
 }
+function roleToAPI({ id, name, description, composite, clientRole, containerId, }) {
+    return {
+        id,
+        name,
+        description,
+        composite,
+        client_role: clientRole,
+        container_id: containerId,
+    };
+}
+exports.roleToAPI = roleToAPI;
 exports.default = Role;

--- a/doc/classes/Account.md
+++ b/doc/classes/Account.md
@@ -43,14 +43,14 @@ Creates an Account object mixing the SDK and API URL together.
 
 #### Parameters
 
-| Name | Type | Default value | Description |
-| :------ | :------ | :------ | :------ |
-| `sdk` | `any` | `undefined` | An instance of a Tozny client SDK. |
-| `apiUrl` | `string` | `DEFAULT_API_URL` | The URL of the Tozny Platform instance to connect to. |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `sdk` | `any` | An instance of a Tozny client SDK. |
+| `apiUrl` | `string` | The URL of the Tozny Platform instance to connect to. |
 
 #### Defined in
 
-[account.ts:30](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L30)
+[account.ts:30](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L30)
 
 ## Accessors
 
@@ -66,7 +66,7 @@ Gets the Tozny Identity constructor provided by the Tozny client SDK.
 
 #### Defined in
 
-[account.ts:58](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L58)
+[account.ts:58](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L58)
 
 ___
 
@@ -84,7 +84,7 @@ The Storage constructor
 
 #### Defined in
 
-[account.ts:49](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L49)
+[account.ts:49](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L49)
 
 ___
 
@@ -100,7 +100,7 @@ gets the current crypto implementation provided by the Tozny client SDK.
 
 #### Defined in
 
-[account.ts:40](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L40)
+[account.ts:40](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L40)
 
 ___
 
@@ -118,7 +118,7 @@ All of the Tozny client SDK defined types.
 
 #### Defined in
 
-[account.ts:67](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L67)
+[account.ts:67](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L67)
 
 ## Methods
 
@@ -143,7 +143,7 @@ An object with the new queen client and paper key.
 
 #### Defined in
 
-[account.ts:325](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L325)
+[account.ts:325](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L325)
 
 ___
 
@@ -172,7 +172,7 @@ A new Client created with all provided values from the object.
 
 #### Defined in
 
-[account.ts:466](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L466)
+[account.ts:466](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L466)
 
 ___
 
@@ -194,7 +194,7 @@ Begin to recover lost account access.
 
 #### Defined in
 
-[account.ts:303](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L303)
+[account.ts:303](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L303)
 
 ___
 
@@ -220,7 +220,7 @@ The Client instance for the provided credentials.
 
 #### Defined in
 
-[account.ts:80](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L80)
+[account.ts:80](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L80)
 
 ___
 
@@ -248,7 +248,7 @@ An object containing the paper key generated at and
 
 #### Defined in
 
-[account.ts:180](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L180)
+[account.ts:180](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L180)
 
 ___
 
@@ -273,7 +273,7 @@ response
 
 #### Defined in
 
-[account.ts:450](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L450)
+[account.ts:450](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L450)
 
 ___
 
@@ -298,4 +298,4 @@ The recovery object for the account
 
 #### Defined in
 
-[account.ts:314](https://github.com/tozny/js-account-sdk/blob/cd90332/src/account.ts#L314)
+[account.ts:314](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L314)

--- a/doc/classes/Account.md
+++ b/doc/classes/Account.md
@@ -50,7 +50,7 @@ Creates an Account object mixing the SDK and API URL together.
 
 #### Defined in
 
-[account.ts:30](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L30)
+[account.ts:30](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L30)
 
 ## Accessors
 
@@ -66,7 +66,7 @@ Gets the Tozny Identity constructor provided by the Tozny client SDK.
 
 #### Defined in
 
-[account.ts:58](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L58)
+[account.ts:58](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L58)
 
 ___
 
@@ -84,7 +84,7 @@ The Storage constructor
 
 #### Defined in
 
-[account.ts:49](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L49)
+[account.ts:49](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L49)
 
 ___
 
@@ -100,7 +100,7 @@ gets the current crypto implementation provided by the Tozny client SDK.
 
 #### Defined in
 
-[account.ts:40](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L40)
+[account.ts:40](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L40)
 
 ___
 
@@ -118,7 +118,7 @@ All of the Tozny client SDK defined types.
 
 #### Defined in
 
-[account.ts:67](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L67)
+[account.ts:67](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L67)
 
 ## Methods
 
@@ -143,7 +143,7 @@ An object with the new queen client and paper key.
 
 #### Defined in
 
-[account.ts:325](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L325)
+[account.ts:325](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L325)
 
 ___
 
@@ -172,7 +172,7 @@ A new Client created with all provided values from the object.
 
 #### Defined in
 
-[account.ts:466](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L466)
+[account.ts:466](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L466)
 
 ___
 
@@ -194,7 +194,7 @@ Begin to recover lost account access.
 
 #### Defined in
 
-[account.ts:303](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L303)
+[account.ts:303](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L303)
 
 ___
 
@@ -220,7 +220,7 @@ The Client instance for the provided credentials.
 
 #### Defined in
 
-[account.ts:80](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L80)
+[account.ts:80](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L80)
 
 ___
 
@@ -248,7 +248,7 @@ An object containing the paper key generated at and
 
 #### Defined in
 
-[account.ts:180](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L180)
+[account.ts:180](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L180)
 
 ___
 
@@ -273,7 +273,7 @@ response
 
 #### Defined in
 
-[account.ts:450](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L450)
+[account.ts:450](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L450)
 
 ___
 
@@ -298,4 +298,4 @@ The recovery object for the account
 
 #### Defined in
 
-[account.ts:314](https://github.com/tozny/js-account-sdk/blob/8282972/src/account.ts#L314)
+[account.ts:314](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L314)

--- a/doc/classes/Account.md
+++ b/doc/classes/Account.md
@@ -50,7 +50,7 @@ Creates an Account object mixing the SDK and API URL together.
 
 #### Defined in
 
-[account.ts:30](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L30)
+[account.ts:30](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L30)
 
 ## Accessors
 
@@ -66,7 +66,7 @@ Gets the Tozny Identity constructor provided by the Tozny client SDK.
 
 #### Defined in
 
-[account.ts:58](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L58)
+[account.ts:58](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L58)
 
 ___
 
@@ -84,7 +84,7 @@ The Storage constructor
 
 #### Defined in
 
-[account.ts:49](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L49)
+[account.ts:49](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L49)
 
 ___
 
@@ -100,7 +100,7 @@ gets the current crypto implementation provided by the Tozny client SDK.
 
 #### Defined in
 
-[account.ts:40](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L40)
+[account.ts:40](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L40)
 
 ___
 
@@ -118,7 +118,7 @@ All of the Tozny client SDK defined types.
 
 #### Defined in
 
-[account.ts:67](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L67)
+[account.ts:67](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L67)
 
 ## Methods
 
@@ -143,7 +143,7 @@ An object with the new queen client and paper key.
 
 #### Defined in
 
-[account.ts:325](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L325)
+[account.ts:325](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L325)
 
 ___
 
@@ -172,7 +172,7 @@ A new Client created with all provided values from the object.
 
 #### Defined in
 
-[account.ts:466](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L466)
+[account.ts:466](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L466)
 
 ___
 
@@ -194,7 +194,7 @@ Begin to recover lost account access.
 
 #### Defined in
 
-[account.ts:303](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L303)
+[account.ts:303](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L303)
 
 ___
 
@@ -220,7 +220,7 @@ The Client instance for the provided credentials.
 
 #### Defined in
 
-[account.ts:80](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L80)
+[account.ts:80](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L80)
 
 ___
 
@@ -248,7 +248,7 @@ An object containing the paper key generated at and
 
 #### Defined in
 
-[account.ts:180](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L180)
+[account.ts:180](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L180)
 
 ___
 
@@ -273,7 +273,7 @@ response
 
 #### Defined in
 
-[account.ts:450](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L450)
+[account.ts:450](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L450)
 
 ___
 
@@ -298,4 +298,4 @@ The recovery object for the account
 
 #### Defined in
 
-[account.ts:314](https://github.com/tozny/js-account-sdk/blob/6d09977/src/account.ts#L314)
+[account.ts:314](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/account.ts#L314)

--- a/doc/classes/Client.md
+++ b/doc/classes/Client.md
@@ -63,7 +63,7 @@ const accountClient = account.client
 - [identityDetails](Client.md#identitydetails)
 - [joinGroups](Client.md#joingroups)
 - [leaveGroups](Client.md#leavegroups)
-- [listAccessPolicies](Client.md#listaccesspolicies)
+- [listAccessPoliciesForGroups](Client.md#listaccesspoliciesforgroups)
 - [listClientInfo](Client.md#listclientinfo)
 - [listDefaultRealmGroups](Client.md#listdefaultrealmgroups)
 - [listGroupRoleMappings](Client.md#listgrouprolemappings)
@@ -93,7 +93,7 @@ const accountClient = account.client
 - [updateRealmGroup](Client.md#updaterealmgroup)
 - [updateRealmRole](Client.md#updaterealmrole)
 - [updateRealmSettings](Client.md#updaterealmsettings)
-- [upsertAccessPolicies](Client.md#upsertaccesspolicies)
+- [upsertAccessPoliciesForGroup](Client.md#upsertaccesspoliciesforgroup)
 - [validatePassword](Client.md#validatepassword)
 - [webhooks](Client.md#webhooks)
 
@@ -114,7 +114,7 @@ const accountClient = account.client
 
 #### Defined in
 
-[client.ts:50](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L50)
+[client.ts:55](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L55)
 
 ## Properties
 
@@ -124,7 +124,7 @@ const accountClient = account.client
 
 #### Defined in
 
-[client.ts:47](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L47)
+[client.ts:52](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L52)
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 #### Defined in
 
-[client.ts:46](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L46)
+[client.ts:51](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L51)
 
 ## Accessors
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[client.ts:57](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L57)
+[client.ts:62](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L62)
 
 ## Methods
 
@@ -168,7 +168,7 @@ ___
 
 #### Defined in
 
-[client.ts:152](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L152)
+[client.ts:157](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L157)
 
 ___
 
@@ -202,7 +202,7 @@ await client.addDefaultRealmGroups(realmName, {
 
 #### Defined in
 
-[client.ts:876](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L876)
+[client.ts:892](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L892)
 
 ___
 
@@ -246,7 +246,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:674](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L674)
+[client.ts:690](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L690)
 
 ___
 
@@ -260,7 +260,7 @@ ___
 
 #### Defined in
 
-[client.ts:142](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L142)
+[client.ts:147](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L147)
 
 ___
 
@@ -280,7 +280,7 @@ ___
 
 #### Defined in
 
-[client.ts:73](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L73)
+[client.ts:78](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L78)
 
 ___
 
@@ -306,7 +306,7 @@ The representation of the created realm returned by the server.
 
 #### Defined in
 
-[client.ts:323](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L323)
+[client.ts:328](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L328)
 
 ___
 
@@ -332,7 +332,7 @@ The newly created role.
 
 #### Defined in
 
-[client.ts:529](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L529)
+[client.ts:545](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L545)
 
 ___
 
@@ -357,7 +357,7 @@ The newly created group.
 
 #### Defined in
 
-[client.ts:380](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L380)
+[client.ts:385](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L385)
 
 ___
 
@@ -372,7 +372,7 @@ Creates a new role for a realm.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `realmName` | `string` | Name of realm. |
-| `role` | `object` | Object with `name` and `description` of role. |
+| `role` | `MinimumRoleData` | Object with `name` and `description` of role. |
 
 #### Returns
 
@@ -382,7 +382,7 @@ The newly created role.
 
 #### Defined in
 
-[client.ts:460](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L460)
+[client.ts:467](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L467)
 
 ___
 
@@ -416,7 +416,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:969](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L969)
+[client.ts:985](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L985)
 
 ___
 
@@ -440,7 +440,7 @@ Empty object.
 
 #### Defined in
 
-[client.ts:354](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L354)
+[client.ts:359](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L359)
 
 ___
 
@@ -466,7 +466,7 @@ True if successful.
 
 #### Defined in
 
-[client.ts:576](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L576)
+[client.ts:592](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L592)
 
 ___
 
@@ -491,7 +491,7 @@ True if successful.
 
 #### Defined in
 
-[client.ts:449](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L449)
+[client.ts:454](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L454)
 
 ___
 
@@ -516,7 +516,7 @@ True if successful.
 
 #### Defined in
 
-[client.ts:492](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L492)
+[client.ts:508](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L508)
 
 ___
 
@@ -540,7 +540,7 @@ True if the operation succeeds.
 
 #### Defined in
 
-[client.ts:227](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L227)
+[client.ts:232](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L232)
 
 ___
 
@@ -564,7 +564,7 @@ True if the operation succeeds.
 
 #### Defined in
 
-[client.ts:267](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L267)
+[client.ts:272](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L272)
 
 ___
 
@@ -588,7 +588,7 @@ Describe a realm application role by id.
 
 #### Defined in
 
-[client.ts:597](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L597)
+[client.ts:613](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L613)
 
 ___
 
@@ -611,7 +611,7 @@ Describe a realm group by id.
 
 #### Defined in
 
-[client.ts:396](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L396)
+[client.ts:401](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L401)
 
 ___
 
@@ -634,7 +634,7 @@ Describe a realm role by id.
 
 #### Defined in
 
-[client.ts:503](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L503)
+[client.ts:519](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L519)
 
 ___
 
@@ -659,7 +659,7 @@ aggregations response object
 
 #### Defined in
 
-[client.ts:306](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L306)
+[client.ts:311](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L311)
 
 ___
 
@@ -679,7 +679,7 @@ ___
 
 #### Defined in
 
-[client.ts:173](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L173)
+[client.ts:178](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L178)
 
 ___
 
@@ -706,7 +706,7 @@ request response object
 
 #### Defined in
 
-[client.ts:281](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L281)
+[client.ts:286](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L286)
 
 ___
 
@@ -735,7 +735,7 @@ const groupList = await client.groupMembership(realmName, identity.toznyId)
 
 #### Defined in
 
-[client.ts:720](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L720)
+[client.ts:736](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L736)
 
 ___
 
@@ -753,7 +753,7 @@ The hosted broker public info.
 
 #### Defined in
 
-[client.ts:1017](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1017)
+[client.ts:1033](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L1033)
 
 ___
 
@@ -778,7 +778,7 @@ A object usable for making paginated queries.
 
 #### Defined in
 
-[client.ts:1090](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1090)
+[client.ts:1106](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L1106)
 
 ___
 
@@ -814,7 +814,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:778](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L778)
+[client.ts:794](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L794)
 
 ___
 
@@ -853,13 +853,13 @@ True if successful
 
 #### Defined in
 
-[client.ts:806](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L806)
+[client.ts:822](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L822)
 
 ___
 
-### listAccessPolicies
+### listAccessPoliciesForGroups
 
-▸ **listAccessPolicies**(`realmName`, `groupIds`): `Promise`<`any`\>
+▸ **listAccessPoliciesForGroups**(`realmName`, `groupIds`): `Promise`<`ListAccessPoliciesResponse`\>
 
 Lists the Current Access Policies for the Group Ids sent.
 
@@ -868,15 +868,15 @@ Lists the Current Access Policies for the Group Ids sent.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `realmName` | `string` | Name of realm. |
-| `groupIds` | [] | The IDs for the Tozny Groups |
+| `groupIds` | `string`[] | The IDs for the Tozny Groups |
 
 #### Returns
 
-`Promise`<`any`\>
+`Promise`<`ListAccessPoliciesResponse`\>
 
 #### Defined in
 
-[client.ts:1131](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1131)
+[client.ts:1147](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L1147)
 
 ___
 
@@ -897,7 +897,7 @@ ___
 
 #### Defined in
 
-[client.ts:164](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L164)
+[client.ts:169](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L169)
 
 ___
 
@@ -926,7 +926,7 @@ List of all groups at realm.
 
 #### Defined in
 
-[client.ts:823](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L823)
+[client.ts:839](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L839)
 
 ___
 
@@ -951,7 +951,7 @@ List of all roles at realm.
 
 #### Defined in
 
-[client.ts:636](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L636)
+[client.ts:652](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L652)
 
 ___
 
@@ -997,7 +997,7 @@ A object usable for making paginated queries.
 
 #### Defined in
 
-[client.ts:1050](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1050)
+[client.ts:1066](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L1066)
 
 ___
 
@@ -1022,7 +1022,7 @@ List of all roles for application.
 
 #### Defined in
 
-[client.ts:617](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L617)
+[client.ts:633](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L633)
 
 ___
 
@@ -1046,7 +1046,7 @@ List of all groups at realm.
 
 #### Defined in
 
-[client.ts:434](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L434)
+[client.ts:439](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L439)
 
 ___
 
@@ -1070,7 +1070,7 @@ List of all roles at realm.
 
 #### Defined in
 
-[client.ts:513](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L513)
+[client.ts:529](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L529)
 
 ___
 
@@ -1088,7 +1088,7 @@ The listed realm representations returned by the server.
 
 #### Defined in
 
-[client.ts:342](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L342)
+[client.ts:347](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L347)
 
 ___
 
@@ -1114,7 +1114,7 @@ The created registration token.
 
 #### Defined in
 
-[client.ts:212](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L212)
+[client.ts:217](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L217)
 
 ___
 
@@ -1139,7 +1139,7 @@ The created webhook.
 
 #### Defined in
 
-[client.ts:251](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L251)
+[client.ts:256](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L256)
 
 ___
 
@@ -1161,7 +1161,7 @@ This will likely be replaced by a call to GET the account profile.
 
 #### Defined in
 
-[client.ts:1109](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1109)
+[client.ts:1125](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L1125)
 
 ___
 
@@ -1205,7 +1205,7 @@ const identityResponse = await accountClient.registerIdentity(
 
 #### Defined in
 
-[client.ts:941](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L941)
+[client.ts:957](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L957)
 
 ___
 
@@ -1230,7 +1230,7 @@ The broker identity for the realm.
 
 #### Defined in
 
-[client.ts:981](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L981)
+[client.ts:997](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L997)
 
 ___
 
@@ -1246,7 +1246,7 @@ Get a list of the current registration tokens for an account.
 
 #### Defined in
 
-[client.ts:198](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L198)
+[client.ts:203](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L203)
 
 ___
 
@@ -1282,7 +1282,7 @@ await client.removeDefaultRealmGroups(realmName, {
 
 #### Defined in
 
-[client.ts:902](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L902)
+[client.ts:918](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L918)
 
 ___
 
@@ -1308,7 +1308,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:695](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L695)
+[client.ts:711](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L711)
 
 ___
 
@@ -1342,7 +1342,7 @@ await client.replaceDefaultRealmGroups(realmName, {
 
 #### Defined in
 
-[client.ts:848](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L848)
+[client.ts:864](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L864)
 
 ___
 
@@ -1358,7 +1358,7 @@ Requests Tozny account email verification be resent.
 
 #### Defined in
 
-[client.ts:1119](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1119)
+[client.ts:1135](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L1135)
 
 ___
 
@@ -1380,7 +1380,7 @@ ___
 
 #### Defined in
 
-[client.ts:1159](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1159)
+[client.ts:1184](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L1184)
 
 ___
 
@@ -1401,7 +1401,7 @@ ___
 
 #### Defined in
 
-[client.ts:178](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L178)
+[client.ts:183](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L183)
 
 ___
 
@@ -1415,7 +1415,7 @@ ___
 
 #### Defined in
 
-[client.ts:156](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L156)
+[client.ts:161](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L161)
 
 ___
 
@@ -1429,7 +1429,7 @@ ___
 
 #### Defined in
 
-[client.ts:160](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L160)
+[client.ts:165](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L165)
 
 ___
 
@@ -1449,7 +1449,7 @@ ___
 
 #### Defined in
 
-[client.ts:147](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L147)
+[client.ts:152](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L152)
 
 ___
 
@@ -1485,7 +1485,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:748](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L748)
+[client.ts:764](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L764)
 
 ___
 
@@ -1508,7 +1508,7 @@ Profile param contains a name and email for the user.
 
 #### Defined in
 
-[client.ts:187](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L187)
+[client.ts:192](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L192)
 
 ___
 
@@ -1533,7 +1533,7 @@ Update an existing application role in the realm given the original role name.
 
 #### Defined in
 
-[client.ts:552](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L552)
+[client.ts:568](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L568)
 
 ___
 
@@ -1557,7 +1557,7 @@ Update an existing group in the realm given a group id.
 
 #### Defined in
 
-[client.ts:414](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L414)
+[client.ts:419](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L419)
 
 ___
 
@@ -1572,15 +1572,17 @@ Update an existing role in the realm given a role id.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `realmName` | `string` | Name of realm. |
-| `role` | `any` | Updated attributes of the role. |
+| `role` | `MinimumRoleWithId` | Updated attributes of the role. |
 
 #### Returns
 
 `Promise`<`Role`\>
 
+The updated role
+
 #### Defined in
 
-[client.ts:476](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L476)
+[client.ts:489](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L489)
 
 ___
 
@@ -1607,13 +1609,13 @@ Updated realm settings.
 
 #### Defined in
 
-[client.ts:366](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L366)
+[client.ts:371](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L371)
 
 ___
 
-### upsertAccessPolicies
+### upsertAccessPoliciesForGroup
 
-▸ **upsertAccessPolicies**(`realmName`, `groupId`, `accessPolicies`): `Promise`<`Identity`\>
+▸ **upsertAccessPoliciesForGroup**(`realmName`, `groupId`, `accessPolicies`): `Promise`<`GroupAccessPolicies`\>
 
  Creating or Updating an Access Policy for a Group
 
@@ -1623,15 +1625,15 @@ ___
 | :------ | :------ | :------ |
 | `realmName` | `string` | Name of realm. |
 | `groupId` | `string` | The ID of the Group in Tozny |
-| `accessPolicies` | `AccessPolicy`[] | Configuration for the new identity |
+| `accessPolicies` | `AccessPolicyData`[] | Configuration for the new identity |
 
 #### Returns
 
-`Promise`<`Identity`\>
+`Promise`<`GroupAccessPolicies`\>
 
 #### Defined in
 
-[client.ts:1146](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1146)
+[client.ts:1167](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L1167)
 
 ___
 
@@ -1651,7 +1653,7 @@ ___
 
 #### Defined in
 
-[client.ts:61](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L61)
+[client.ts:66](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L66)
 
 ___
 
@@ -1667,4 +1669,4 @@ Get a list of the current webhooks for an account.
 
 #### Defined in
 
-[client.ts:237](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L237)
+[client.ts:242](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/client.ts#L242)

--- a/doc/classes/Client.md
+++ b/doc/classes/Client.md
@@ -92,6 +92,7 @@ const accountClient = account.client
 - [updateRealmApplicationRole](Client.md#updaterealmapplicationrole)
 - [updateRealmGroup](Client.md#updaterealmgroup)
 - [updateRealmRole](Client.md#updaterealmrole)
+- [updateRealmSettings](Client.md#updaterealmsettings)
 - [upsertAccessPolicies](Client.md#upsertaccesspolicies)
 - [validatePassword](Client.md#validatepassword)
 - [webhooks](Client.md#webhooks)
@@ -113,7 +114,7 @@ const accountClient = account.client
 
 #### Defined in
 
-[client.ts:49](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L49)
+[client.ts:50](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L50)
 
 ## Properties
 
@@ -123,7 +124,7 @@ const accountClient = account.client
 
 #### Defined in
 
-[client.ts:46](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L46)
+[client.ts:47](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L47)
 
 ___
 
@@ -133,7 +134,7 @@ ___
 
 #### Defined in
 
-[client.ts:45](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L45)
+[client.ts:46](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L46)
 
 ## Accessors
 
@@ -147,7 +148,7 @@ ___
 
 #### Defined in
 
-[client.ts:56](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L56)
+[client.ts:57](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L57)
 
 ## Methods
 
@@ -167,7 +168,7 @@ ___
 
 #### Defined in
 
-[client.ts:151](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L151)
+[client.ts:152](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L152)
 
 ___
 
@@ -201,7 +202,7 @@ await client.addDefaultRealmGroups(realmName, {
 
 #### Defined in
 
-[client.ts:860](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L860)
+[client.ts:876](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L876)
 
 ___
 
@@ -245,7 +246,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:658](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L658)
+[client.ts:674](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L674)
 
 ___
 
@@ -259,7 +260,7 @@ ___
 
 #### Defined in
 
-[client.ts:141](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L141)
+[client.ts:142](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L142)
 
 ___
 
@@ -279,7 +280,7 @@ ___
 
 #### Defined in
 
-[client.ts:72](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L72)
+[client.ts:73](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L73)
 
 ___
 
@@ -305,7 +306,7 @@ The representation of the created realm returned by the server.
 
 #### Defined in
 
-[client.ts:322](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L322)
+[client.ts:323](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L323)
 
 ___
 
@@ -331,7 +332,7 @@ The newly created role.
 
 #### Defined in
 
-[client.ts:513](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L513)
+[client.ts:529](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L529)
 
 ___
 
@@ -356,7 +357,7 @@ The newly created group.
 
 #### Defined in
 
-[client.ts:364](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L364)
+[client.ts:380](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L380)
 
 ___
 
@@ -381,7 +382,7 @@ The newly created role.
 
 #### Defined in
 
-[client.ts:444](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L444)
+[client.ts:460](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L460)
 
 ___
 
@@ -415,7 +416,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:953](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L953)
+[client.ts:969](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L969)
 
 ___
 
@@ -439,7 +440,7 @@ Empty object.
 
 #### Defined in
 
-[client.ts:353](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L353)
+[client.ts:354](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L354)
 
 ___
 
@@ -465,7 +466,7 @@ True if successful.
 
 #### Defined in
 
-[client.ts:560](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L560)
+[client.ts:576](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L576)
 
 ___
 
@@ -490,7 +491,7 @@ True if successful.
 
 #### Defined in
 
-[client.ts:433](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L433)
+[client.ts:449](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L449)
 
 ___
 
@@ -515,7 +516,7 @@ True if successful.
 
 #### Defined in
 
-[client.ts:476](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L476)
+[client.ts:492](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L492)
 
 ___
 
@@ -539,7 +540,7 @@ True if the operation succeeds.
 
 #### Defined in
 
-[client.ts:226](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L226)
+[client.ts:227](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L227)
 
 ___
 
@@ -563,7 +564,7 @@ True if the operation succeeds.
 
 #### Defined in
 
-[client.ts:266](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L266)
+[client.ts:267](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L267)
 
 ___
 
@@ -587,7 +588,7 @@ Describe a realm application role by id.
 
 #### Defined in
 
-[client.ts:581](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L581)
+[client.ts:597](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L597)
 
 ___
 
@@ -610,7 +611,7 @@ Describe a realm group by id.
 
 #### Defined in
 
-[client.ts:380](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L380)
+[client.ts:396](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L396)
 
 ___
 
@@ -633,7 +634,7 @@ Describe a realm role by id.
 
 #### Defined in
 
-[client.ts:487](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L487)
+[client.ts:503](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L503)
 
 ___
 
@@ -658,7 +659,7 @@ aggregations response object
 
 #### Defined in
 
-[client.ts:305](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L305)
+[client.ts:306](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L306)
 
 ___
 
@@ -678,7 +679,7 @@ ___
 
 #### Defined in
 
-[client.ts:172](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L172)
+[client.ts:173](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L173)
 
 ___
 
@@ -705,7 +706,7 @@ request response object
 
 #### Defined in
 
-[client.ts:280](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L280)
+[client.ts:281](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L281)
 
 ___
 
@@ -734,7 +735,7 @@ const groupList = await client.groupMembership(realmName, identity.toznyId)
 
 #### Defined in
 
-[client.ts:704](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L704)
+[client.ts:720](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L720)
 
 ___
 
@@ -752,7 +753,7 @@ The hosted broker public info.
 
 #### Defined in
 
-[client.ts:1001](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1001)
+[client.ts:1017](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1017)
 
 ___
 
@@ -777,7 +778,7 @@ A object usable for making paginated queries.
 
 #### Defined in
 
-[client.ts:1074](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1074)
+[client.ts:1090](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1090)
 
 ___
 
@@ -813,7 +814,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:762](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L762)
+[client.ts:778](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L778)
 
 ___
 
@@ -852,7 +853,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:790](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L790)
+[client.ts:806](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L806)
 
 ___
 
@@ -875,7 +876,7 @@ Lists the Current Access Policies for the Group Ids sent.
 
 #### Defined in
 
-[client.ts:1115](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1115)
+[client.ts:1131](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1131)
 
 ___
 
@@ -896,7 +897,7 @@ ___
 
 #### Defined in
 
-[client.ts:163](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L163)
+[client.ts:164](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L164)
 
 ___
 
@@ -925,7 +926,7 @@ List of all groups at realm.
 
 #### Defined in
 
-[client.ts:807](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L807)
+[client.ts:823](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L823)
 
 ___
 
@@ -950,7 +951,7 @@ List of all roles at realm.
 
 #### Defined in
 
-[client.ts:620](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L620)
+[client.ts:636](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L636)
 
 ___
 
@@ -996,7 +997,7 @@ A object usable for making paginated queries.
 
 #### Defined in
 
-[client.ts:1034](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1034)
+[client.ts:1050](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1050)
 
 ___
 
@@ -1021,7 +1022,7 @@ List of all roles for application.
 
 #### Defined in
 
-[client.ts:601](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L601)
+[client.ts:617](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L617)
 
 ___
 
@@ -1045,7 +1046,7 @@ List of all groups at realm.
 
 #### Defined in
 
-[client.ts:418](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L418)
+[client.ts:434](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L434)
 
 ___
 
@@ -1069,7 +1070,7 @@ List of all roles at realm.
 
 #### Defined in
 
-[client.ts:497](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L497)
+[client.ts:513](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L513)
 
 ___
 
@@ -1087,7 +1088,7 @@ The listed realm representations returned by the server.
 
 #### Defined in
 
-[client.ts:341](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L341)
+[client.ts:342](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L342)
 
 ___
 
@@ -1113,7 +1114,7 @@ The created registration token.
 
 #### Defined in
 
-[client.ts:211](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L211)
+[client.ts:212](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L212)
 
 ___
 
@@ -1138,7 +1139,7 @@ The created webhook.
 
 #### Defined in
 
-[client.ts:250](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L250)
+[client.ts:251](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L251)
 
 ___
 
@@ -1160,7 +1161,7 @@ This will likely be replaced by a call to GET the account profile.
 
 #### Defined in
 
-[client.ts:1093](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1093)
+[client.ts:1109](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1109)
 
 ___
 
@@ -1204,7 +1205,7 @@ const identityResponse = await accountClient.registerIdentity(
 
 #### Defined in
 
-[client.ts:925](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L925)
+[client.ts:941](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L941)
 
 ___
 
@@ -1229,7 +1230,7 @@ The broker identity for the realm.
 
 #### Defined in
 
-[client.ts:965](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L965)
+[client.ts:981](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L981)
 
 ___
 
@@ -1245,7 +1246,7 @@ Get a list of the current registration tokens for an account.
 
 #### Defined in
 
-[client.ts:197](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L197)
+[client.ts:198](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L198)
 
 ___
 
@@ -1281,7 +1282,7 @@ await client.removeDefaultRealmGroups(realmName, {
 
 #### Defined in
 
-[client.ts:886](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L886)
+[client.ts:902](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L902)
 
 ___
 
@@ -1307,7 +1308,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:679](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L679)
+[client.ts:695](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L695)
 
 ___
 
@@ -1341,7 +1342,7 @@ await client.replaceDefaultRealmGroups(realmName, {
 
 #### Defined in
 
-[client.ts:832](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L832)
+[client.ts:848](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L848)
 
 ___
 
@@ -1357,7 +1358,7 @@ Requests Tozny account email verification be resent.
 
 #### Defined in
 
-[client.ts:1103](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1103)
+[client.ts:1119](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1119)
 
 ___
 
@@ -1379,7 +1380,7 @@ ___
 
 #### Defined in
 
-[client.ts:1143](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1143)
+[client.ts:1159](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1159)
 
 ___
 
@@ -1400,7 +1401,7 @@ ___
 
 #### Defined in
 
-[client.ts:177](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L177)
+[client.ts:178](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L178)
 
 ___
 
@@ -1414,7 +1415,7 @@ ___
 
 #### Defined in
 
-[client.ts:155](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L155)
+[client.ts:156](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L156)
 
 ___
 
@@ -1428,7 +1429,7 @@ ___
 
 #### Defined in
 
-[client.ts:159](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L159)
+[client.ts:160](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L160)
 
 ___
 
@@ -1448,7 +1449,7 @@ ___
 
 #### Defined in
 
-[client.ts:146](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L146)
+[client.ts:147](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L147)
 
 ___
 
@@ -1484,7 +1485,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:732](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L732)
+[client.ts:748](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L748)
 
 ___
 
@@ -1507,7 +1508,7 @@ Profile param contains a name and email for the user.
 
 #### Defined in
 
-[client.ts:186](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L186)
+[client.ts:187](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L187)
 
 ___
 
@@ -1532,7 +1533,7 @@ Update an existing application role in the realm given the original role name.
 
 #### Defined in
 
-[client.ts:536](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L536)
+[client.ts:552](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L552)
 
 ___
 
@@ -1556,7 +1557,7 @@ Update an existing group in the realm given a group id.
 
 #### Defined in
 
-[client.ts:398](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L398)
+[client.ts:414](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L414)
 
 ___
 
@@ -1579,7 +1580,34 @@ Update an existing role in the realm given a role id.
 
 #### Defined in
 
-[client.ts:460](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L460)
+[client.ts:476](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L476)
+
+___
+
+### updateRealmSettings
+
+▸ **updateRealmSettings**(`realmName`, `settings`): `Promise`<`RealmSettings`\>
+
+Updates settings for the realm.
+Some of these features enabled by these settings are experimental and may be subject
+to change.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `realmName` | `string` | Name of realm. |
+| `settings` | `RealmSettings` | Object containing settings to enable. |
+
+#### Returns
+
+`Promise`<`RealmSettings`\>
+
+Updated realm settings.
+
+#### Defined in
+
+[client.ts:366](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L366)
 
 ___
 
@@ -1603,7 +1631,7 @@ ___
 
 #### Defined in
 
-[client.ts:1130](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1130)
+[client.ts:1146](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L1146)
 
 ___
 
@@ -1623,7 +1651,7 @@ ___
 
 #### Defined in
 
-[client.ts:60](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L60)
+[client.ts:61](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L61)
 
 ___
 
@@ -1639,4 +1667,4 @@ Get a list of the current webhooks for an account.
 
 #### Defined in
 
-[client.ts:236](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L236)
+[client.ts:237](https://github.com/tozny/js-account-sdk/blob/6d09977/src/client.ts#L237)

--- a/doc/classes/Client.md
+++ b/doc/classes/Client.md
@@ -63,6 +63,7 @@ const accountClient = account.client
 - [identityDetails](Client.md#identitydetails)
 - [joinGroups](Client.md#joingroups)
 - [leaveGroups](Client.md#leavegroups)
+- [listAccessPolicies](Client.md#listaccesspolicies)
 - [listClientInfo](Client.md#listclientinfo)
 - [listDefaultRealmGroups](Client.md#listdefaultrealmgroups)
 - [listGroupRoleMappings](Client.md#listgrouprolemappings)
@@ -91,6 +92,7 @@ const accountClient = account.client
 - [updateRealmApplicationRole](Client.md#updaterealmapplicationrole)
 - [updateRealmGroup](Client.md#updaterealmgroup)
 - [updateRealmRole](Client.md#updaterealmrole)
+- [upsertAccessPolicies](Client.md#upsertaccesspolicies)
 - [validatePassword](Client.md#validatepassword)
 - [webhooks](Client.md#webhooks)
 
@@ -111,7 +113,7 @@ const accountClient = account.client
 
 #### Defined in
 
-[client.ts:48](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L48)
+[client.ts:49](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L49)
 
 ## Properties
 
@@ -121,7 +123,7 @@ const accountClient = account.client
 
 #### Defined in
 
-[client.ts:45](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L45)
+[client.ts:46](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L46)
 
 ___
 
@@ -131,7 +133,7 @@ ___
 
 #### Defined in
 
-[client.ts:44](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L44)
+[client.ts:45](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L45)
 
 ## Accessors
 
@@ -145,7 +147,7 @@ ___
 
 #### Defined in
 
-[client.ts:55](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L55)
+[client.ts:56](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L56)
 
 ## Methods
 
@@ -165,7 +167,7 @@ ___
 
 #### Defined in
 
-[client.ts:150](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L150)
+[client.ts:151](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L151)
 
 ___
 
@@ -199,7 +201,7 @@ await client.addDefaultRealmGroups(realmName, {
 
 #### Defined in
 
-[client.ts:859](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L859)
+[client.ts:860](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L860)
 
 ___
 
@@ -243,7 +245,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:657](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L657)
+[client.ts:658](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L658)
 
 ___
 
@@ -257,7 +259,7 @@ ___
 
 #### Defined in
 
-[client.ts:140](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L140)
+[client.ts:141](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L141)
 
 ___
 
@@ -277,7 +279,7 @@ ___
 
 #### Defined in
 
-[client.ts:71](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L71)
+[client.ts:72](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L72)
 
 ___
 
@@ -303,7 +305,7 @@ The representation of the created realm returned by the server.
 
 #### Defined in
 
-[client.ts:321](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L321)
+[client.ts:322](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L322)
 
 ___
 
@@ -329,7 +331,7 @@ The newly created role.
 
 #### Defined in
 
-[client.ts:512](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L512)
+[client.ts:513](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L513)
 
 ___
 
@@ -354,7 +356,7 @@ The newly created group.
 
 #### Defined in
 
-[client.ts:363](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L363)
+[client.ts:364](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L364)
 
 ___
 
@@ -379,7 +381,7 @@ The newly created role.
 
 #### Defined in
 
-[client.ts:443](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L443)
+[client.ts:444](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L444)
 
 ___
 
@@ -413,7 +415,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:952](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L952)
+[client.ts:953](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L953)
 
 ___
 
@@ -437,7 +439,7 @@ Empty object.
 
 #### Defined in
 
-[client.ts:352](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L352)
+[client.ts:353](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L353)
 
 ___
 
@@ -463,7 +465,7 @@ True if successful.
 
 #### Defined in
 
-[client.ts:559](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L559)
+[client.ts:560](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L560)
 
 ___
 
@@ -488,7 +490,7 @@ True if successful.
 
 #### Defined in
 
-[client.ts:432](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L432)
+[client.ts:433](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L433)
 
 ___
 
@@ -513,7 +515,7 @@ True if successful.
 
 #### Defined in
 
-[client.ts:475](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L475)
+[client.ts:476](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L476)
 
 ___
 
@@ -537,7 +539,7 @@ True if the operation succeeds.
 
 #### Defined in
 
-[client.ts:225](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L225)
+[client.ts:226](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L226)
 
 ___
 
@@ -561,7 +563,7 @@ True if the operation succeeds.
 
 #### Defined in
 
-[client.ts:265](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L265)
+[client.ts:266](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L266)
 
 ___
 
@@ -585,7 +587,7 @@ Describe a realm application role by id.
 
 #### Defined in
 
-[client.ts:580](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L580)
+[client.ts:581](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L581)
 
 ___
 
@@ -608,7 +610,7 @@ Describe a realm group by id.
 
 #### Defined in
 
-[client.ts:379](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L379)
+[client.ts:380](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L380)
 
 ___
 
@@ -631,7 +633,7 @@ Describe a realm role by id.
 
 #### Defined in
 
-[client.ts:486](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L486)
+[client.ts:487](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L487)
 
 ___
 
@@ -656,7 +658,7 @@ aggregations response object
 
 #### Defined in
 
-[client.ts:304](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L304)
+[client.ts:305](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L305)
 
 ___
 
@@ -676,7 +678,7 @@ ___
 
 #### Defined in
 
-[client.ts:171](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L171)
+[client.ts:172](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L172)
 
 ___
 
@@ -703,7 +705,7 @@ request response object
 
 #### Defined in
 
-[client.ts:279](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L279)
+[client.ts:280](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L280)
 
 ___
 
@@ -732,7 +734,7 @@ const groupList = await client.groupMembership(realmName, identity.toznyId)
 
 #### Defined in
 
-[client.ts:703](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L703)
+[client.ts:704](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L704)
 
 ___
 
@@ -750,7 +752,7 @@ The hosted broker public info.
 
 #### Defined in
 
-[client.ts:1000](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L1000)
+[client.ts:1001](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1001)
 
 ___
 
@@ -775,7 +777,7 @@ A object usable for making paginated queries.
 
 #### Defined in
 
-[client.ts:1069](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L1069)
+[client.ts:1074](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1074)
 
 ___
 
@@ -811,7 +813,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:761](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L761)
+[client.ts:762](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L762)
 
 ___
 
@@ -850,7 +852,30 @@ True if successful
 
 #### Defined in
 
-[client.ts:789](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L789)
+[client.ts:790](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L790)
+
+___
+
+### listAccessPolicies
+
+▸ **listAccessPolicies**(`realmName`, `groupIds`): `Promise`<`any`\>
+
+Lists the Current Access Policies for the Group Ids sent.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `realmName` | `string` | Name of realm. |
+| `groupIds` | [] | The IDs for the Tozny Groups |
+
+#### Returns
+
+`Promise`<`any`\>
+
+#### Defined in
+
+[client.ts:1115](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1115)
 
 ___
 
@@ -871,7 +896,7 @@ ___
 
 #### Defined in
 
-[client.ts:162](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L162)
+[client.ts:163](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L163)
 
 ___
 
@@ -900,7 +925,7 @@ List of all groups at realm.
 
 #### Defined in
 
-[client.ts:806](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L806)
+[client.ts:807](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L807)
 
 ___
 
@@ -925,7 +950,7 @@ List of all roles at realm.
 
 #### Defined in
 
-[client.ts:619](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L619)
+[client.ts:620](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L620)
 
 ___
 
@@ -959,9 +984,9 @@ identities allowed by the server
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `realmName` | `any` | Name of realm. |
-| `max` | `any` | The maximum number of identities per page. Up to the max allowed by the server. |
-| `next` | `any` | The next token, used for paging. Default is 0. |
+| `realmName` | `string` | Name of realm. |
+| `max` | `number` | The maximum number of identities per page. Up to the max allowed by the server. |
+| `next` | `number` | The next token, used for paging. Default is 0. |
 
 #### Returns
 
@@ -971,7 +996,7 @@ A object usable for making paginated queries.
 
 #### Defined in
 
-[client.ts:1033](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L1033)
+[client.ts:1034](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1034)
 
 ___
 
@@ -996,7 +1021,7 @@ List of all roles for application.
 
 #### Defined in
 
-[client.ts:600](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L600)
+[client.ts:601](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L601)
 
 ___
 
@@ -1020,7 +1045,7 @@ List of all groups at realm.
 
 #### Defined in
 
-[client.ts:417](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L417)
+[client.ts:418](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L418)
 
 ___
 
@@ -1044,7 +1069,7 @@ List of all roles at realm.
 
 #### Defined in
 
-[client.ts:496](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L496)
+[client.ts:497](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L497)
 
 ___
 
@@ -1062,7 +1087,7 @@ The listed realm representations returned by the server.
 
 #### Defined in
 
-[client.ts:340](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L340)
+[client.ts:341](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L341)
 
 ___
 
@@ -1088,7 +1113,7 @@ The created registration token.
 
 #### Defined in
 
-[client.ts:210](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L210)
+[client.ts:211](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L211)
 
 ___
 
@@ -1113,7 +1138,7 @@ The created webhook.
 
 #### Defined in
 
-[client.ts:249](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L249)
+[client.ts:250](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L250)
 
 ___
 
@@ -1135,7 +1160,7 @@ This will likely be replaced by a call to GET the account profile.
 
 #### Defined in
 
-[client.ts:1088](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L1088)
+[client.ts:1093](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1093)
 
 ___
 
@@ -1179,7 +1204,7 @@ const identityResponse = await accountClient.registerIdentity(
 
 #### Defined in
 
-[client.ts:924](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L924)
+[client.ts:925](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L925)
 
 ___
 
@@ -1204,7 +1229,7 @@ The broker identity for the realm.
 
 #### Defined in
 
-[client.ts:964](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L964)
+[client.ts:965](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L965)
 
 ___
 
@@ -1220,7 +1245,7 @@ Get a list of the current registration tokens for an account.
 
 #### Defined in
 
-[client.ts:196](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L196)
+[client.ts:197](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L197)
 
 ___
 
@@ -1256,7 +1281,7 @@ await client.removeDefaultRealmGroups(realmName, {
 
 #### Defined in
 
-[client.ts:885](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L885)
+[client.ts:886](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L886)
 
 ___
 
@@ -1282,7 +1307,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:678](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L678)
+[client.ts:679](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L679)
 
 ___
 
@@ -1316,7 +1341,7 @@ await client.replaceDefaultRealmGroups(realmName, {
 
 #### Defined in
 
-[client.ts:831](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L831)
+[client.ts:832](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L832)
 
 ___
 
@@ -1332,7 +1357,7 @@ Requests Tozny account email verification be resent.
 
 #### Defined in
 
-[client.ts:1098](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L1098)
+[client.ts:1103](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1103)
 
 ___
 
@@ -1354,7 +1379,7 @@ ___
 
 #### Defined in
 
-[client.ts:1103](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L1103)
+[client.ts:1143](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1143)
 
 ___
 
@@ -1375,7 +1400,7 @@ ___
 
 #### Defined in
 
-[client.ts:176](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L176)
+[client.ts:177](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L177)
 
 ___
 
@@ -1389,7 +1414,7 @@ ___
 
 #### Defined in
 
-[client.ts:154](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L154)
+[client.ts:155](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L155)
 
 ___
 
@@ -1403,7 +1428,7 @@ ___
 
 #### Defined in
 
-[client.ts:158](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L158)
+[client.ts:159](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L159)
 
 ___
 
@@ -1423,7 +1448,7 @@ ___
 
 #### Defined in
 
-[client.ts:145](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L145)
+[client.ts:146](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L146)
 
 ___
 
@@ -1459,7 +1484,7 @@ True if successful
 
 #### Defined in
 
-[client.ts:731](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L731)
+[client.ts:732](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L732)
 
 ___
 
@@ -1482,7 +1507,7 @@ Profile param contains a name and email for the user.
 
 #### Defined in
 
-[client.ts:185](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L185)
+[client.ts:186](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L186)
 
 ___
 
@@ -1507,7 +1532,7 @@ Update an existing application role in the realm given the original role name.
 
 #### Defined in
 
-[client.ts:535](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L535)
+[client.ts:536](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L536)
 
 ___
 
@@ -1531,7 +1556,7 @@ Update an existing group in the realm given a group id.
 
 #### Defined in
 
-[client.ts:397](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L397)
+[client.ts:398](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L398)
 
 ___
 
@@ -1554,7 +1579,31 @@ Update an existing role in the realm given a role id.
 
 #### Defined in
 
-[client.ts:459](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L459)
+[client.ts:460](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L460)
+
+___
+
+### upsertAccessPolicies
+
+▸ **upsertAccessPolicies**(`realmName`, `groupId`, `accessPolicies`): `Promise`<`Identity`\>
+
+ Creating or Updating an Access Policy for a Group
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `realmName` | `string` | Name of realm. |
+| `groupId` | `string` | The ID of the Group in Tozny |
+| `accessPolicies` | `AccessPolicy`[] | Configuration for the new identity |
+
+#### Returns
+
+`Promise`<`Identity`\>
+
+#### Defined in
+
+[client.ts:1130](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L1130)
 
 ___
 
@@ -1574,7 +1623,7 @@ ___
 
 #### Defined in
 
-[client.ts:59](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L59)
+[client.ts:60](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L60)
 
 ___
 
@@ -1590,4 +1639,4 @@ Get a list of the current webhooks for an account.
 
 #### Defined in
 
-[client.ts:235](https://github.com/tozny/js-account-sdk/blob/cd90332/src/client.ts#L235)
+[client.ts:236](https://github.com/tozny/js-account-sdk/blob/8282972/src/client.ts#L236)

--- a/doc/modules.md
+++ b/doc/modules.md
@@ -21,4 +21,4 @@
 
 #### Defined in
 
-[index.ts:1](https://github.com/tozny/js-account-sdk/blob/8282972/src/index.ts#L1)
+[index.ts:1](https://github.com/tozny/js-account-sdk/blob/6d09977/src/index.ts#L1)

--- a/doc/modules.md
+++ b/doc/modules.md
@@ -21,4 +21,4 @@
 
 #### Defined in
 
-[index.ts:1](https://github.com/tozny/js-account-sdk/blob/6d09977/src/index.ts#L1)
+[index.ts:1](https://github.com/tozny/js-account-sdk/blob/4cea62b/src/index.ts#L1)

--- a/doc/modules.md
+++ b/doc/modules.md
@@ -17,4 +17,8 @@
 
 ### default
 
-Renames and re-exports [Account](classes/Account.md)
+• **default**: `Object`
+
+#### Defined in
+
+[index.ts:1](https://github.com/tozny/js-account-sdk/blob/8282972/src/index.ts#L1)

--- a/src/__tests__/pam.test.ts
+++ b/src/__tests__/pam.test.ts
@@ -1,0 +1,63 @@
+import Account from '../account'
+// @ts-ignore no type defs exist for js-sdk
+import Tozny from '@toznysecure/sdk/node'
+import { v4 as uuidv4 } from 'uuid'
+import { cleanupRealms } from './utils'
+import { Role } from '../types'
+
+const accountFactory = new Account(Tozny, process.env.API_URL)
+let client: any = null
+let realmName: string
+let seed: string
+let sovereignName: string
+
+beforeAll(async () => {
+  // Create an account to re-use across test cases
+  seed = uuidv4()
+  const name = `Test Account ${seed}`
+  const email = `test+${seed}@tozny.com`
+  const password = uuidv4()
+  const registration: any = await accountFactory.register(name, email, password)
+  client = registration.client
+
+  realmName = `TestRealm${seed.split('-')[0]}`
+  sovereignName = 'yassqueen'
+  await client.createRealm(realmName, sovereignName)
+})
+
+afterAll(async () => {
+  await cleanupRealms(client)
+})
+
+describe('Identity', () => {
+  it('Can Create and list a Access Policy', async () => {
+    // creation of group
+    const adminGroup = await client.createRealmGroup(realmName, {
+      name: 'Admins',
+      attributes: {
+        key1: 'value1',
+        key2: 'value2',
+      },
+    })
+
+    expect(adminGroup.id).toBeTruthy()
+    expect(adminGroup.name).toBe('Admins')
+    expect(adminGroup.attributes.key1).toBe('value1')
+    expect(adminGroup.attributes.key2).toBe('value2')
+    // list groups expected to have Admins
+    const groups = await client.listRealmGroups(realmName)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].id).toBe(adminGroup.id)
+    expect(groups[0].name).toBe('Admins')
+
+    // List all current realm roles
+    const realmRoles: Role[] = await client.listRealmRoles(realmName)
+    // there are two default roles plus the two created above
+    expect(realmRoles).toHaveLength(4)
+    const roleNames = realmRoles.map(r => r.name)
+    // 2 default realm roles
+    expect(roleNames).toContain('offline_access')
+    expect(roleNames).toContain('uma_authorization')
+    // TODO Need to update Realm Settings
+  })
+})

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -1,7 +1,31 @@
+import { v4 as uuidv4 } from 'uuid'
+import Account, { Client } from '..'
+
+type TestRealmData = {
+  client: Client
+  realmName: string
+}
+export async function createTestRealm(
+  accountFactory: Account
+): Promise<TestRealmData> {
+  const seed = uuidv4()
+  const name = `Test Account ${seed}`
+  const email = `test+${seed}@tozny.com`
+  const password = uuidv4()
+  const registration: any = await accountFactory.register(name, email, password)
+  const client = registration.client as Client
+
+  const realmName = `TestRealm${seed.split('-')[0]}`
+  const sovereignName = 'yassqueen'
+  await client.createRealm(realmName, sovereignName)
+
+  return { client, realmName }
+}
+
 /**
  * cleanupRealms deletes all realms associated with a Tozny client.
  */
-export async function cleanupRealms(client: any): Promise<void> {
+export async function cleanupRealms(client: Client): Promise<void> {
   // Cleanup all created realms
   const realms = await client.listRealms()
   for (let realm of realms.realms) {

--- a/src/api/identity.ts
+++ b/src/api/identity.ts
@@ -28,7 +28,6 @@ type RealmInfoData = {
 type RealmInfoResponse = {
   domain: string
   name: string
-  domamain: string
 }
 export async function realmInfo({
   realm_name,
@@ -94,6 +93,51 @@ export async function deleteIdentity(
       headers: {
         'Content-Type': 'application/json',
       },
+    }
+  )
+  checkStatus(response)
+  return
+}
+
+type RealmSettingData = {
+  realm_name: string
+  apiUrl: string
+  secretsEnabled: boolean
+  mfaAvailable: []
+  emailLookupsEnabled: boolean
+  tozIDFederationEnabled: boolean
+  mpcEnabled: boolean
+}
+
+export async function updateRealmSettings(
+  {
+    realm_name,
+    secretsEnabled,
+    mfaAvailable,
+    emailLookupsEnabled,
+    tozIDFederationEnabled,
+    mpcEnabled,
+  }: RealmSettingData,
+  { apiUrl, queenClient }: APIContext
+): Promise<void> {
+  // Get the Realm Domain
+  const info = await realmInfo({ realm_name, apiUrl })
+  const payload = {
+    secrets_enabled: secretsEnabled,
+    mfa_available: mfaAvailable,
+    email_lookups_enabled: emailLookupsEnabled,
+    tozid_federation_enabled: tozIDFederationEnabled,
+    mpc_enabled: mpcEnabled,
+  }
+  // Update Realm Settings
+  const response = await queenClient.authenticator.tsv1Fetch(
+    `${apiUrl}/v1/identity/admin/realm/info/${info.domain}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
     }
   )
   checkStatus(response)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,54 +4,63 @@
  */
 import fetch from 'isomorphic-fetch'
 import {
-  createRealmRole,
-  updateRealmRole,
-  deleteRealmRole,
-  describeRealmRole,
-  listRealmRoles,
-} from './realmRoles'
-import Token from './token'
-import Role, { ToznyAPIRole } from '../types/role'
-import { validateRequestAsJSON, checkStatus } from '../utils'
-import { DEFAULT_API_URL } from '../utils/constants'
+  AccessPolicyData,
+  ToznyAPIGroupAccessPolicies,
+} from '../types/accessPolicy'
 import { ToznyAPIGroup } from '../types/group'
-import {
-  createRealmGroup,
-  updateRealmGroup,
-  deleteRealmGroup,
-  describeRealmGroup,
-  listRealmGroups,
-} from './realmGroups'
 import { ToznyAPIGroupRoleMapping } from '../types/groupRoleMapping'
+import Identity, { ToznyAPIIdentity } from '../types/identity'
+import { ToznyAPIListAccessPoliciesResponse } from '../types/listAccessPoliciesResponse'
+import RealmSettings from '../types/realmSettings'
+import { MinimumRoleData, MinimumRoleWithId, ToznyAPIRole } from '../types/role'
+import { checkStatus, validateRequestAsJSON } from '../utils'
+import { DEFAULT_API_URL } from '../utils/constants'
+import {
+  addDefaultRealmGroups,
+  listDefaultRealmGroups,
+  removeDefaultRealmGroups,
+  replaceDefaultRealmGroups,
+} from './defaultRealmGroups'
+import {
+  groupMembership,
+  joinGroups,
+  leaveGroups,
+  updateGroupMembership,
+} from './groupMembership'
 import {
   addGroupRoleMappings,
   GroupRoleMappingInput,
   listGroupRoleMappings,
   removeGroupRoleMappings,
 } from './groupRoleMappings'
+import { deleteIdentity, registerIdentity } from './identity'
 import {
-  leaveGroups,
-  joinGroups,
-  updateGroupMembership,
-  groupMembership,
-} from './groupMembership'
+  listAccessPoliciesForGroups,
+  upsertAccessPoliciesForGroup,
+} from './pam'
 import {
   createRealmApplicationRole,
-  updateRealmApplicationRole,
   deleteRealmApplicationRole,
   describeRealmApplicationRole,
   listRealmApplicationRoles,
+  updateRealmApplicationRole,
 } from './realmApplicationRoles'
 import {
-  listDefaultRealmGroups,
-  replaceDefaultRealmGroups,
-  addDefaultRealmGroups,
-  removeDefaultRealmGroups,
-} from './defaultRealmGroups'
-import { deleteIdentity, registerIdentity } from './identity'
-import Identity, { ToznyAPIIdentity } from '../types/identity'
-import RealmSettings from '../types/realmSettings'
+  createRealmGroup,
+  deleteRealmGroup,
+  describeRealmGroup,
+  listRealmGroups,
+  updateRealmGroup,
+} from './realmGroups'
+import {
+  createRealmRole,
+  deleteRealmRole,
+  describeRealmRole,
+  listRealmRoles,
+  updateRealmRole,
+} from './realmRoles'
 import { updateRealmSettings } from './realmSettings'
+import Token from './token'
 
 // this is a placeholder until we have real types from js-sdk
 type ToznyClient = any
@@ -770,7 +779,7 @@ class API {
   async createRealmRole(
     queenClient: ToznyClient,
     realmName: string,
-    role: Role
+    role: MinimumRoleData
   ): Promise<ToznyAPIRole> {
     return createRealmRole(
       { realmName, role },
@@ -784,7 +793,7 @@ class API {
   async updateRealmRole(
     queenClient: ToznyClient,
     realmName: string,
-    role: { name: string; description: string }
+    role: MinimumRoleWithId
   ): Promise<ToznyAPIRole> {
     return updateRealmRole(
       { realmName, role },
@@ -838,7 +847,7 @@ class API {
     queenClient: ToznyClient,
     realmName: string,
     applicationId: string,
-    role: Role
+    role: MinimumRoleData
   ): Promise<ToznyAPIRole> {
     return createRealmApplicationRole(
       { realmName, applicationId, role },
@@ -854,7 +863,7 @@ class API {
     realmName: string,
     applicationId: string,
     originalRoleName: string,
-    role: { name: string; description: string }
+    role: MinimumRoleWithId
   ): Promise<ToznyAPIRole> {
     return updateRealmApplicationRole(
       { realmName, applicationId, originalRoleName, role },
@@ -1172,6 +1181,29 @@ class API {
       }
     )
     return validateRequestAsJSON(response)
+  }
+
+  async listAccessPoliciesForGroups(
+    queenClient: ToznyClient,
+    realmName: string,
+    groupIds: string[]
+  ): Promise<ToznyAPIListAccessPoliciesResponse> {
+    return listAccessPoliciesForGroups(
+      { realmName, groupIds },
+      { apiUrl: this.apiUrl, queenClient }
+    )
+  }
+
+  async upsertAccessPoliciesForGroup(
+    queenClient: ToznyClient,
+    realmName: string,
+    groupId: string,
+    accessPolicies: AccessPolicyData[]
+  ): Promise<ToznyAPIGroupAccessPolicies> {
+    return upsertAccessPoliciesForGroup(
+      { realmName, groupId, accessPolicies },
+      { apiUrl: this.apiUrl, queenClient }
+    )
   }
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,9 +22,7 @@ import {
   describeRealmGroup,
   listRealmGroups,
 } from './realmGroups'
-import GroupRoleMapping, {
-  ToznyAPIGroupRoleMapping,
-} from '../types/groupRoleMapping'
+import { ToznyAPIGroupRoleMapping } from '../types/groupRoleMapping'
 import {
   addGroupRoleMappings,
   GroupRoleMappingInput,
@@ -52,6 +50,8 @@ import {
 } from './defaultRealmGroups'
 import { deleteIdentity, registerIdentity } from './identity'
 import Identity, { ToznyAPIIdentity } from '../types/identity'
+import RealmSettings from '../types/realmSettings'
+import { updateRealmSettings } from './realmSettings'
 
 // this is a placeholder until we have real types from js-sdk
 type ToznyClient = any
@@ -598,6 +598,7 @@ class API {
     )
     return validateRequestAsJSON(response)
   }
+
   /**
    * Requests the creation of a new TozID Realm.
    *
@@ -661,6 +662,20 @@ class API {
       }
     )
     return validateRequestAsJSON(response)
+  }
+
+  /** Updates the settings for the given realm. */
+  async updateRealmSettings(
+    queenClient: ToznyClient,
+    realmName: string,
+    settings: RealmSettings
+  ): Promise<RealmSettings> {
+    await updateRealmSettings(
+      { realmName, settings },
+      { apiUrl: this.apiUrl, queenClient }
+    )
+    // no error means it worked
+    return settings
   }
 
   async getAggregations(queenClient, accountId, startTime, endTime) {
@@ -1048,15 +1063,15 @@ class API {
   }
 
   /**
-   *
+   * Registers a new identity with the realm
    */
   async registerIdentity(
-    realm_name: string,
-    realm_registration_token: string,
+    realmName: string,
+    realmRegistrationToken: string,
     identity: ToznyAPIIdentity
   ): Promise<void> {
     return registerIdentity(
-      { realm_name, realm_registration_token, identity },
+      { realmName, realmRegistrationToken, identity },
       { apiUrl: this.apiUrl }
     )
   }

--- a/src/api/pam.ts
+++ b/src/api/pam.ts
@@ -1,0 +1,85 @@
+import { validateRequestAsJSON, checkStatus } from '../utils'
+import { APIContext } from './context'
+import { ToznyAPIRole } from '../types/role'
+import AccessPolicy, { ToznyAPIAccessPolicy } from '../types/accessPolicy'
+import { roleToAPI } from '../types/role'
+
+type PAMRealmSettings = {
+  mpc_enabled_for_realm: boolean
+  default_access_duration_seconds: number
+  default_required_approvals: number
+}
+
+type GroupAccessPolicies = {
+  id: string
+  access_policies: ToznyAPIAccessPolicy[]
+}
+
+type ListAccessPolicyData = {
+  realmName: string
+  groupIds: []
+}
+
+type ListAccessPolicyResponse = {
+  settings: PAMRealmSettings
+  groups: GroupAccessPolicies[]
+}
+
+export async function listAccessPolicies(
+  { realmName, groupIds }: ListAccessPolicyData,
+  { apiUrl, queenClient }: APIContext
+): Promise<ListAccessPolicyResponse> {
+  var query = new URLSearchParams()
+  query.set('realm_name', encodeURIComponent(realmName))
+  groupIds.forEach(groupId =>
+    query.append('group_ids', encodeURIComponent(groupId))
+  )
+  const request = await queenClient.authenticator.tsv1Fetch(
+    apiUrl + '/v1/identity/pam/polcies?${query.toString()}',
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  )
+  const accessPolicyResponse = (await validateRequestAsJSON(
+    request
+  )) as ListAccessPolicyResponse
+  return accessPolicyResponse
+}
+
+type UpsertPolicyData = {
+  realmName: string
+  groupId: string
+  accessPolicies: AccessPolicy[]
+}
+export async function UpsertAccessPolicies(
+  { realmName, groupId, accessPolicies }: UpsertPolicyData,
+  { apiUrl, queenClient }: APIContext
+): Promise<void> {
+  const payload = {
+    realm_name: realmName,
+    group: {
+      id: groupId,
+      accessPolicies: accessPolicies.map(ap => ({
+        id: ap.id,
+        required_approvals: ap.requiredApprovals,
+        max_access_duration_seconds: ap.maxAccessDurationSeconds,
+        approval_roles: ap.approvalRoles.map(roleToAPI),
+      })),
+    },
+  }
+  const response = await queenClient.authenticator.tsv1Fetch(
+    `${apiUrl}/v1/identity/pam/policies`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }
+  )
+  checkStatus(response)
+  return
+}

--- a/src/api/pam.ts
+++ b/src/api/pam.ts
@@ -1,6 +1,5 @@
 import { validateRequestAsJSON, checkStatus } from '../utils'
 import { APIContext } from './context'
-import { ToznyAPIRole } from '../types/role'
 import AccessPolicy, { ToznyAPIAccessPolicy } from '../types/accessPolicy'
 import { roleToAPI } from '../types/role'
 
@@ -54,7 +53,7 @@ type UpsertPolicyData = {
   groupId: string
   accessPolicies: AccessPolicy[]
 }
-export async function UpsertAccessPolicies(
+export async function upsertAccessPolicies(
   { realmName, groupId, accessPolicies }: UpsertPolicyData,
   { apiUrl, queenClient }: APIContext
 ): Promise<void> {

--- a/src/api/realmRoles.ts
+++ b/src/api/realmRoles.ts
@@ -1,10 +1,10 @@
 import { checkStatus, validateRequestAsJSON } from '../utils'
 import { APIContext } from './context'
-import { ToznyAPIRole } from '../types/role'
+import { MinimumRoleData, MinimumRoleWithId, ToznyAPIRole } from '../types/role'
 
 type CreateRealmRoleData = {
   realmName: string
-  role: { name: string; description: string }
+  role: MinimumRoleData
 }
 
 export async function createRealmRole(
@@ -23,7 +23,7 @@ export async function createRealmRole(
 
 type UpdateRealmRoleData = {
   realmName: string
-  role: { id: string; name: string; description: string }
+  role: MinimumRoleWithId
 }
 export async function updateRealmRole(
   { realmName, role }: UpdateRealmRoleData,

--- a/src/api/realmSettings.ts
+++ b/src/api/realmSettings.ts
@@ -53,7 +53,7 @@ export async function updateRealmSettings(
   const response = await queenClient.authenticator.tsv1Fetch(
     `${apiUrl}/v1/identity/admin/realm/info/${info.domain}`,
     {
-      method: 'GET',
+      method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     }

--- a/src/api/realmSettings.ts
+++ b/src/api/realmSettings.ts
@@ -1,0 +1,63 @@
+import RealmSettings, { ToznyAPIRealmSettings } from '../types/realmSettings'
+import { checkStatus, validateRequestAsJSON } from '../utils'
+import { APIContext } from './context'
+
+type RealmInfoData = {
+  realmName: string
+}
+type RealmInfoResponse = {
+  domain: string
+  name: string
+}
+/** not publicly exposed. used primarily internally for realmName -> domainName conversion */
+export async function getRealmInfo(
+  { realmName }: RealmInfoData,
+  { apiUrl }: APIContext
+): Promise<RealmInfoResponse> {
+  const response = await fetch(
+    `${apiUrl}/v1/identity/info/realm/${realmName.toLowerCase()}`,
+    { method: 'GET', headers: { 'Content-Type': 'application/json' } }
+  )
+  const realmInfo = (await validateRequestAsJSON(response)) as RealmInfoResponse
+  return realmInfo
+}
+
+type UpdateRealmSettingsData = {
+  realmName: string
+  apiUrl: string
+  settings: RealmSettings
+}
+export async function updateRealmSettings(
+  {
+    realmName,
+    settings: {
+      secretsEnabled,
+      mfaAvailable,
+      emailLookupsEnabled,
+      tozIDFederationEnabled,
+      mpcEnabled,
+    },
+  }: UpdateRealmSettingsData,
+  { apiUrl, queenClient }: APIContext
+): Promise<void> {
+  // Get the Realm Domain
+  const info = await getRealmInfo({ realmName }, { apiUrl, queenClient })
+  const payload: ToznyAPIRealmSettings = {
+    secrets_enabled: secretsEnabled,
+    mfa_available: mfaAvailable,
+    email_lookups_enabled: emailLookupsEnabled,
+    tozid_federation_enabled: tozIDFederationEnabled,
+    mpc_enabled: mpcEnabled,
+  }
+  // Update Realm Settings
+  const response = await queenClient.authenticator.tsv1Fetch(
+    `${apiUrl}/v1/identity/admin/realm/info/${info.domain}`,
+    {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }
+  )
+  checkStatus(response)
+  return
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,6 +22,7 @@ import ListIdentitiesResult from './types/listIdentitiesResult'
 import DetailedIdentity from './types/detailedIdentity'
 import Account from '.'
 import AccessPolicy from './types/accessPolicy'
+import RealmSettings from './types/realmSettings'
 
 /**
  * The client for Tozny's Account API.
@@ -352,6 +353,21 @@ class Client {
    */
   async deleteRealm(realmName: string): Promise<object> {
     return this.api.deleteRealm(this.queenClient, realmName)
+  }
+
+  /**
+   * Updates settings for the realm.
+   * Some of these features enabled by these settings are experimental and may be subject
+   * to change.
+   * @param {string} realmName Name of realm.
+   * @param {RealmSettings} settings Object containing settings to enable.
+   * @returns Updated realm settings.
+   */
+  async updateRealmSettings(
+    realmName: string,
+    settings: RealmSettings
+  ): Promise<RealmSettings> {
+    return this.api.updateRealmSettings(this.queenClient, realmName, settings)
   }
 
   /**
@@ -1110,7 +1126,7 @@ class Client {
    *
    * @param {string} realmName Name of realm.
    * @param {Array} groupIds  The IDs for the Tozny Groups
-   * @returns {Promise<ListAccessPolicyResponse>}
+   * @returns {Promise<AccessPolicy>}
    */
   async listAccessPolicies(
     realmName: string,
@@ -1132,7 +1148,7 @@ class Client {
     groupId: string,
     accessPolicies: AccessPolicy[]
   ): Promise<Identity> {
-    return this.api.UpsertAccessPolicies(
+    return this.api.upsertAccessPolicies(
       this.queenClient,
       realmName,
       groupId,

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,6 +21,7 @@ import BasicIdentity from './types/basicIdentity'
 import ListIdentitiesResult from './types/listIdentitiesResult'
 import DetailedIdentity from './types/detailedIdentity'
 import Account from '.'
+import AccessPolicy from './types/accessPolicy'
 
 /**
  * The client for Tozny's Account API.
@@ -1102,6 +1103,41 @@ class Client {
   async resendVerificationEmail() {
     const email = this.profile.email
     return this.api.resendVerificationEmail(email)
+  }
+
+  /**
+   * Lists the Current Access Policies for the Group Ids sent.
+   *
+   * @param {string} realmName Name of realm.
+   * @param {Array} groupIds  The IDs for the Tozny Groups
+   * @returns {Promise<ListAccessPolicyResponse>}
+   */
+  async listAccessPolicies(
+    realmName: string,
+    groupIds: []
+  ): Promise<ListAccessPolicyResponse> {
+    return this.api.listAccessPolicies(this.queenClient, realmName, groupIds)
+  }
+
+  /**
+   *  Creating or Updating an Access Policy for a Group
+   *
+   * @param {string} realmName Name of realm.
+   * @param {string} groupId The ID of the Group in Tozny
+   * @param {AccessPolicy[]} accessPolicies Configuration for the new identity
+   * @returns {Promise<ListAccessPolicyResponse>}
+   */
+  async upsertAccessPolicies(
+    realmName: string,
+    groupId: string,
+    accessPolicies: AccessPolicy[]
+  ): Promise<Identity> {
+    return this.api.UpsertAccessPolicies(
+      this.queenClient,
+      realmName,
+      groupId,
+      accessPolicies
+    )
   }
 
   serialize() {

--- a/src/types/accessPolicy.ts
+++ b/src/types/accessPolicy.ts
@@ -1,45 +1,28 @@
-import Role, { ToznyAPIRole } from './role'
+import Role, { MinimumRoleWithId, ToznyAPIRole } from './role'
 
 class AccessPolicy {
   id: string
   approvalRoles: Role[]
-  requiredApprovals: string
-  maxAccessDurationSeconds: string
+  requiredApprovals: number
+  maxAccessDurationSeconds: number
 
   constructor(
     id: string,
-    approval_roles: Role[],
-    required_approvals: string,
-    max_access_duration_seconds: string
+    approvalRoles: Role[],
+    requiredApprovals: number,
+    maxAccessDurationSeconds: number
   ) {
     this.id = id
-    this.approvalRoles = approval_roles
-    this.maxAccessDurationSeconds = max_access_duration_seconds
-    this.requiredApprovals = required_approvals
+    this.approvalRoles = approvalRoles
+    this.maxAccessDurationSeconds = maxAccessDurationSeconds
+    this.requiredApprovals = requiredApprovals
   }
 
   /**
    * Specify how an already unserialized JSON array should be marshaled into
    * an object representation.
    *
-   * <code>
-   * access_policy = AccessPolicy::decode({
-   *   id: '00000000-0000-0000-0000-000000000000',
-   *   approval_roles: Role::decode({
-   *   id: '00000000-0000-0000-0000-000000000000',
-   *   name: 'jsmith',
-   *   description: 'This role provides access to...'
-   *   composite: false',
-   *   client_role: trie,
-   *   container_id: '00000000-0000-0000-0000-000000000000',
-   * })
-   *   max_access_duration_seconds: '00',
-   *   required_approvals: '00',
-   * })
-   * <code>
-   *
-   * @param {object} json
-   *
+   * @param {ToznyAPIAccessPolicy} json
    * @return {<AccessPolicy>}
    */
   static decode(json: ToznyAPIAccessPolicy): AccessPolicy {
@@ -53,11 +36,27 @@ class AccessPolicy {
   }
 }
 
+export type AccessPolicyData = {
+  id?: string
+  approvalRoles: MinimumRoleWithId[]
+  requiredApprovals: number
+  maxAccessDurationSeconds: number
+}
 export type ToznyAPIAccessPolicy = {
   id: string
   approval_roles: ToznyAPIRole[]
-  required_approvals: string
-  max_access_duration_seconds: string
+  required_approvals: number
+  max_access_duration_seconds: number
 }
 
+export type GroupAccessPolicies = {
+  /** Id of group */
+  id: string
+  /** List of access policies for group */
+  accessPolicies: AccessPolicy[]
+}
+export type ToznyAPIGroupAccessPolicies = {
+  id: string
+  access_policies: ToznyAPIAccessPolicy[]
+}
 export default AccessPolicy

--- a/src/types/accessPolicy.ts
+++ b/src/types/accessPolicy.ts
@@ -1,0 +1,63 @@
+import Role, { ToznyAPIRole } from './role'
+
+class AccessPolicy {
+  id: string
+  approvalRoles: Role[]
+  requiredApprovals: string
+  maxAccessDurationSeconds: string
+
+  constructor(
+    id: string,
+    approval_roles: Role[],
+    required_approvals: string,
+    max_access_duration_seconds: string
+  ) {
+    this.id = id
+    this.approvalRoles = approval_roles
+    this.maxAccessDurationSeconds = max_access_duration_seconds
+    this.requiredApprovals = required_approvals
+  }
+
+  /**
+   * Specify how an already unserialized JSON array should be marshaled into
+   * an object representation.
+   *
+   * <code>
+   * access_policy = AccessPolicy::decode({
+   *   id: '00000000-0000-0000-0000-000000000000',
+   *   approval_roles: Role::decode({
+   *   id: '00000000-0000-0000-0000-000000000000',
+   *   name: 'jsmith',
+   *   description: 'This role provides access to...'
+   *   composite: false',
+   *   client_role: trie,
+   *   container_id: '00000000-0000-0000-0000-000000000000',
+   * })
+   *   max_access_duration_seconds: '00',
+   *   required_approvals: '00',
+   * })
+   * <code>
+   *
+   * @param {object} json
+   *
+   * @return {<AccessPolicy>}
+   */
+  static decode(json: ToznyAPIAccessPolicy): AccessPolicy {
+    const realmRoles = json.approval_roles.map(Role.decode)
+    return new AccessPolicy(
+      json.id,
+      realmRoles,
+      json.required_approvals,
+      json.max_access_duration_seconds
+    )
+  }
+}
+
+export type ToznyAPIAccessPolicy = {
+  id: string
+  approval_roles: ToznyAPIRole[]
+  required_approvals: string
+  max_access_duration_seconds: string
+}
+
+export default AccessPolicy

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -2,6 +2,7 @@
  * Exposes the various defined types used in the Account SDK for easy consumption.
  */
 
+const AccessPolicy = require('./accessPolicy').default
 const AccountBillingStatus = require('./accountBillingStatus')
 const BasicIdentity = require('./basicIdentity').default
 const ClientInfo = require('./clientInfo')
@@ -18,6 +19,7 @@ const Role = require('./role').default
 const Sovereign = require('./sovereign')
 
 module.exports = {
+  AccessPolicy,
   AccountBillingStatus,
   BasicIdentity,
   ClientInfo,

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -11,6 +11,8 @@ const DetailedIdentity = require('./detailedIdentity')
 const Group = require('./group').default
 const GroupRoleMapping = require('./groupRoleMapping').default
 const Identity = require('./identity').default
+const ListAccessPoliciesResponse = require('./listAccessPoliciesResponse')
+  .default
 const ListIdentitiesResult = require('./listIdentitiesResult')
 const Realm = require('./realm')
 const Realms = require('./realms')
@@ -26,12 +28,13 @@ module.exports = {
   ClientInfoList,
   DetailedIdentity,
   Group,
+  GroupRoleMapping,
   Identity,
+  ListAccessPoliciesResponse,
   ListIdentitiesResult,
   Realm,
   Realms,
   RegistrationToken,
   Role,
-  GroupRoleMapping,
   Sovereign,
 }

--- a/src/types/listAccessPoliciesResponse.ts
+++ b/src/types/listAccessPoliciesResponse.ts
@@ -1,0 +1,46 @@
+import AccessPolicy, {
+  GroupAccessPolicies,
+  ToznyAPIGroupAccessPolicies,
+} from './accessPolicy'
+
+class ListAccessPoliciesResponse {
+  constructor(
+    public settings: RealmPAMSettings,
+    public groupAccessPolicies: GroupAccessPolicies[]
+  ) {}
+
+  static decode(
+    api: ToznyAPIListAccessPoliciesResponse
+  ): ListAccessPoliciesResponse {
+    const groups: GroupAccessPolicies[] = api.groups.map(
+      ({ id, access_policies }) => ({
+        id,
+        accessPolicies: access_policies.map(AccessPolicy.decode),
+      })
+    )
+    const settings: RealmPAMSettings = {
+      defaultAccessDurationSeconds:
+        api.settings.default_access_duration_seconds,
+      defaultRequiredApprovals: api.settings.default_required_approvals,
+      mpcEnabledForRealm: api.settings.mpc_enabled_for_realm,
+    }
+    return new ListAccessPoliciesResponse(settings, groups)
+  }
+}
+
+export type RealmPAMSettings = {
+  defaultAccessDurationSeconds: number
+  defaultRequiredApprovals: number
+  mpcEnabledForRealm: boolean
+}
+
+export type ToznyAPIListAccessPoliciesResponse = {
+  settings: {
+    mpc_enabled_for_realm: boolean
+    default_access_duration_seconds: number
+    default_required_approvals: number
+  }
+  groups: ToznyAPIGroupAccessPolicies[]
+}
+
+export default ListAccessPoliciesResponse

--- a/src/types/realmSettings.ts
+++ b/src/types/realmSettings.ts
@@ -1,0 +1,36 @@
+/**
+ * RealmSettings is a simple type that represents custom setting for a realm.
+ */
+type RealmSettings = {
+  emailLookupsEnabled?: boolean
+  mfaAvailable?: string[]
+  mpcEnabled?: boolean
+  secretsEnabled?: boolean
+  tozIDFederationEnabled?: boolean
+}
+
+/** RealmInfo contains the name & domain name of realm. */
+export type RealmInfo = { name: string; domain: string }
+
+export type ToznyAPIRealmSettings = Required<{
+  secrets_enabled: RealmSettings['secretsEnabled']
+  mfa_available: RealmSettings['mfaAvailable']
+  email_lookups_enabled: RealmSettings['emailLookupsEnabled']
+  tozid_federation_enabled: RealmSettings['tozIDFederationEnabled']
+  mpc_enabled: RealmSettings['mpcEnabled']
+}>
+
+/**
+ * decodeRealmSettings converts the API response type to the structure used by this package.
+ */
+export function decodeRealmSettings(api: ToznyAPIRealmSettings): RealmSettings {
+  return {
+    emailLookupsEnabled: api.secrets_enabled,
+    mfaAvailable: api.mfa_available,
+    mpcEnabled: api.email_lookups_enabled,
+    secretsEnabled: api.tozid_federation_enabled,
+    tozIDFederationEnabled: api.mpc_enabled,
+  }
+}
+
+export default RealmSettings

--- a/src/types/role.ts
+++ b/src/types/role.ts
@@ -5,17 +5,17 @@ class Role {
   id: string
   name: string
   description: string
-  composite: boolean
-  clientRole: boolean
-  containerId: string
+  composite?: boolean
+  clientRole?: boolean
+  containerId?: string
 
   constructor(
     id: string,
     name: string,
     description: string,
-    composite: boolean,
-    clientRole: boolean,
-    containerId: string
+    composite?: boolean,
+    clientRole?: boolean,
+    containerId?: string
   ) {
     this.id = id
     this.name = name
@@ -60,18 +60,21 @@ export type ToznyAPIRole = {
   id: string
   name: string
   description: string
-  composite: boolean
-  client_role: boolean
-  container_id: string
+  composite?: boolean
+  client_role?: boolean
+  container_id?: string
 }
 type RoleData = {
   id: string
   name: string
   description: string
-  composite: boolean
-  clientRole: boolean
-  containerId: string
+  composite?: boolean
+  clientRole?: boolean
+  containerId?: string
 }
+
+export type MinimumRoleData = { name: string; description: string }
+export type MinimumRoleWithId = { id: string } & MinimumRoleData
 
 export function roleToAPI({
   id,

--- a/src/types/role.ts
+++ b/src/types/role.ts
@@ -64,5 +64,30 @@ export type ToznyAPIRole = {
   client_role: boolean
   container_id: string
 }
+type RoleData = {
+  id: string
+  name: string
+  description: string
+  composite: boolean
+  clientRole: boolean
+  containerId: string
+}
 
+export function roleToAPI({
+  id,
+  name,
+  description,
+  composite,
+  clientRole,
+  containerId,
+}: RoleData): ToznyAPIRole {
+  return {
+    id,
+    name,
+    description,
+    composite,
+    client_role: clientRole,
+    container_id: containerId,
+  }
+}
 export default Role


### PR DESCRIPTION
New client methods:
* `updateRealmSettings`
* `upsertAccessPoliciesForGroup`
* `listAccessPoliciesForGroups`

Per usual, please ignore `dist` changes.

Not included here: I want to update some things w/r/t the types exposed to the documentation so they are more meaningful. Extra docs work to follow (including examples).

[WR-244]

[WR-244]: https://toznysecurity.atlassian.net/browse/WR-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ