### PR TITLE
inject placeholder type for Tozny's js-sdk

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,18 @@
     "module": "commonjs" /* Specify what module code is generated. */,
     "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. */,
-    "strict": true /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+    "typeRoots": [
+      "./node_modules/@types",
+      "./types"
+    ] /* List of folders to include type definitions from. */
   },
   "include": ["./src/**/*"],
-  "exclude": ["./src/__tests__"]
+  "exclude": ["./src/__tests__"],
+  "typeRoots": [
+    "./node_modules/@types",
+    "./types"
+  ] /* List of folders to include type definitions from. */
 }

--- a/types/@toznysecure__sdk__node/index.d.ts
+++ b/types/@toznysecure__sdk__node/index.d.ts
@@ -1,0 +1,8 @@
+// because no type defs exist, i just override the module with `any`
+// someday hopefully we will add these to js-sdk
+declare module '@toznysecure/sdk/node' {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore we can use any as a value below because we are just replacing the real thing with
+  // a fake type.
+  export default any
+}


### PR DESCRIPTION
this fixes the Travis CI pipeline. it explicitly sets the `Tozny` class's type to `any` (because we have no type definition for that package)

will not merge unless travis correctly builds & passes